### PR TITLE
Add seeding scripts for Farscape, The Expanse, and Stargate Universe

### DIFF
--- a/seed_farscape.sh
+++ b/seed_farscape.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API="${API:-http://localhost:3000}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"; exit 1
+fi
+
+json() { jq -c -n "$1"; }
+
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$API/init" | grep -qE '^(200|201|204)$' && echo "[init] Database ensured" || echo "[init] Skipped or not supported"
+
+SHOW_ID=$(curl -s "$API/shows" | jq -r '
+  map(select(.title=="Farscape" and .year==1999)) | (.[0].id // empty)
+')
+if [ -z "${SHOW_ID:-}" ]; then
+  SHOW_ID=$(curl -s -X POST "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"Farscape", description:"Australian-American science fiction series", year:1999}')" | jq -r '.id')
+  echo "Created show: Farscape (id=$SHOW_ID)"
+else
+  echo "Using existing show: Farscape (id=$SHOW_ID)"
+fi
+
+read -r -d '' SEASONS <<'EOF2' || true
+1|1999
+2|2000
+3|2001
+4|2002
+EOF2
+
+existing_seasons=$(curl -s "$API/shows/$SHOW_ID/seasons")
+printf '%s\n' "$SEASONS" | while IFS='|' read -r s y; do
+  [ -z "$s" ] && continue
+  if echo "$existing_seasons" | jq -e --argjson s "$s" 'map(.season_number)|index($s)' >/dev/null; then
+    echo "Season $s already exists"
+  else
+    echo "Creating Season $s (year $y)"
+    curl -s -X POST "$API/shows/$SHOW_ID/seasons" -H 'Content-Type: application/json' -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
+  fi
+done
+
+read -r -d '' ACTORS <<'EOF2' || true
+Ben Browder
+Claudia Black
+Anthony Simcoe
+Gigi Edgley
+EOF2
+
+actors_json=$(curl -s "$API/actors")
+printf '%s\n' "$ACTORS" | while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  if echo "$actors_json" | jq -e --arg n "$name" 'map(.name)|index($n)' >/dev/null; then
+    echo "Actor exists: $name"
+  else
+    echo "Creating actor: $name"
+    curl -s -X POST "$API/actors" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
+  fi
+done
+actors_json=$(curl -s "$API/actors")
+
+read -r -d '' CHAR_TO_ACTOR <<'EOF2' || true
+John Crichton|Ben Browder
+Aeryn Sun|Claudia Black
+Ka D'Argo|Anthony Simcoe
+Chiana|Gigi Edgley
+EOF2
+
+chars_json=$(curl -s "$API/shows/$SHOW_ID/characters")
+printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
+  [ -z "$char" ] && continue
+  if echo "$chars_json" | jq -e --arg n "$char" 'map(.name)|index($n)' >/dev/null; then
+    echo "Character exists: $char"
+  else
+    echo "Creating character: $char (actor: $actor)"
+    curl -s -X POST "$API/shows/$SHOW_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
+  fi
+done
+
+read -r -d '' EPISODES <<'EOF2' || true
+1|1999-03-19|Premiere|Series premiere.
+2|2000-03-17|Mind the Baby|Season 2 opener.
+3|2001-03-16|Season of Death|Season 3 opener.
+4|2002-06-07|Crichton Kicks|Season 4 opener.
+EOF2
+
+existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
+printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
+  [ -z "$season" ] && continue
+  if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
+    echo "Episode exists (S${season}): $title"
+  else
+    echo "Creating episode (S${season}): $title"
+    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+  fi
+  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
+  [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
+  for char in John\ Crichton "Aeryn Sun" "Ka D'Argo" Chiana; do
+    echo "  Linking $char"
+    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+  done
+done
+
+echo "Farscape seeding complete"

--- a/seed_stargate_universe.sh
+++ b/seed_stargate_universe.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API="${API:-http://localhost:3000}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"; exit 1
+fi
+
+json() { jq -c -n "$1"; }
+
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$API/init" | grep -qE '^(200|201|204)$' && echo "[init] Database ensured" || echo "[init] Skipped or not supported"
+
+SHOW_ID=$(curl -s "$API/shows" | jq -r '
+  map(select(.title=="Stargate Universe" and .year==2009)) | (.[0].id // empty)
+')
+if [ -z "${SHOW_ID:-}" ]; then
+  SHOW_ID=$(curl -s -X POST "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"Stargate Universe", description:"Canadian-American military science fiction series", year:2009}')" | jq -r '.id')
+  echo "Created show: Stargate Universe (id=$SHOW_ID)"
+else
+  echo "Using existing show: Stargate Universe (id=$SHOW_ID)"
+fi
+
+read -r -d '' SEASONS <<'EOF2' || true
+1|2009
+2|2010
+EOF2
+
+existing_seasons=$(curl -s "$API/shows/$SHOW_ID/seasons")
+printf '%s\n' "$SEASONS" | while IFS='|' read -r s y; do
+  [ -z "$s" ] && continue
+  if echo "$existing_seasons" | jq -e --argjson s "$s" 'map(.season_number)|index($s)' >/dev/null; then
+    echo "Season $s already exists"
+  else
+    echo "Creating Season $s (year $y)"
+    curl -s -X POST "$API/shows/$SHOW_ID/seasons" -H 'Content-Type: application/json' -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
+  fi
+done
+
+read -r -d '' ACTORS <<'EOF2' || true
+Robert Carlyle
+Louis Ferreira
+David Blue
+Elyse Levesque
+EOF2
+
+actors_json=$(curl -s "$API/actors")
+printf '%s\n' "$ACTORS" | while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  if echo "$actors_json" | jq -e --arg n "$name" 'map(.name)|index($n)' >/dev/null; then
+    echo "Actor exists: $name"
+  else
+    echo "Creating actor: $name"
+    curl -s -X POST "$API/actors" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
+  fi
+done
+actors_json=$(curl -s "$API/actors")
+
+read -r -d '' CHAR_TO_ACTOR <<'EOF2' || true
+Dr. Nicholas Rush|Robert Carlyle
+Col. Everett Young|Louis Ferreira
+Eli Wallace|David Blue
+Chloe Armstrong|Elyse Levesque
+EOF2
+
+chars_json=$(curl -s "$API/shows/$SHOW_ID/characters")
+printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
+  [ -z "$char" ] && continue
+  if echo "$chars_json" | jq -e --arg n "$char" 'map(.name)|index($n)' >/dev/null; then
+    echo "Character exists: $char"
+  else
+    echo "Creating character: $char (actor: $actor)"
+    curl -s -X POST "$API/shows/$SHOW_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
+  fi
+done
+
+read -r -d '' EPISODES <<'EOF2' || true
+1|2009-10-02|Air (Part 1)|Series premiere.
+2|2010-09-28|Intervention|Season 2 opener.
+EOF2
+
+existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
+printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
+  [ -z "$season" ] && continue
+  if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
+    echo "Episode exists (S${season}): $title"
+  else
+    echo "Creating episode (S${season}): $title"
+    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+  fi
+  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
+  [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
+  for char in "Dr. Nicholas Rush" "Col. Everett Young" "Eli Wallace" "Chloe Armstrong"; do
+    echo "  Linking $char"
+    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+  done
+done
+
+echo "Stargate Universe seeding complete"

--- a/seed_the_expanse.sh
+++ b/seed_the_expanse.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+API="${API:-http://localhost:3000}"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required"; exit 1
+fi
+
+json() { jq -c -n "$1"; }
+
+curl -s -o /dev/null -w "%{http_code}\n" -X POST "$API/init" | grep -qE '^(200|201|204)$' && echo "[init] Database ensured" || echo "[init] Skipped or not supported"
+
+SHOW_ID=$(curl -s "$API/shows" | jq -r '
+  map(select(.title=="The Expanse" and .year==2015)) | (.[0].id // empty)
+')
+if [ -z "${SHOW_ID:-}" ]; then
+  SHOW_ID=$(curl -s -X POST "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"The Expanse", description:"American science fiction series", year:2015}')" | jq -r '.id')
+  echo "Created show: The Expanse (id=$SHOW_ID)"
+else
+  echo "Using existing show: The Expanse (id=$SHOW_ID)"
+fi
+
+read -r -d '' SEASONS <<'EOF2' || true
+1|2015
+2|2017
+3|2018
+4|2019
+5|2020
+6|2021
+EOF2
+
+existing_seasons=$(curl -s "$API/shows/$SHOW_ID/seasons")
+printf '%s\n' "$SEASONS" | while IFS='|' read -r s y; do
+  [ -z "$s" ] && continue
+  if echo "$existing_seasons" | jq -e --argjson s "$s" 'map(.season_number)|index($s)' >/dev/null; then
+    echo "Season $s already exists"
+  else
+    echo "Creating Season $s (year $y)"
+    curl -s -X POST "$API/shows/$SHOW_ID/seasons" -H 'Content-Type: application/json' -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
+  fi
+done
+
+read -r -d '' ACTORS <<'EOF2' || true
+Steven Strait
+Dominique Tipper
+Cas Anvar
+Wes Chatham
+EOF2
+
+actors_json=$(curl -s "$API/actors")
+printf '%s\n' "$ACTORS" | while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  if echo "$actors_json" | jq -e --arg n "$name" 'map(.name)|index($n)' >/dev/null; then
+    echo "Actor exists: $name"
+  else
+    echo "Creating actor: $name"
+    curl -s -X POST "$API/actors" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
+  fi
+done
+actors_json=$(curl -s "$API/actors")
+
+read -r -d '' CHAR_TO_ACTOR <<'EOF2' || true
+James Holden|Steven Strait
+Naomi Nagata|Dominique Tipper
+Alex Kamal|Cas Anvar
+Amos Burton|Wes Chatham
+EOF2
+
+chars_json=$(curl -s "$API/shows/$SHOW_ID/characters")
+printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
+  [ -z "$char" ] && continue
+  if echo "$chars_json" | jq -e --arg n "$char" 'map(.name)|index($n)' >/dev/null; then
+    echo "Character exists: $char"
+  else
+    echo "Creating character: $char (actor: $actor)"
+    curl -s -X POST "$API/shows/$SHOW_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
+  fi
+done
+
+read -r -d '' EPISODES <<'EOF2' || true
+1|2015-12-14|Dulcinea|Series premiere.
+2|2017-02-01|Safe|Season 2 opener.
+3|2018-04-11|Fight or Flight|Season 3 opener.
+4|2019-12-13|New Terra|Season 4 opener.
+5|2020-12-16|Exodus|Season 5 opener.
+6|2021-12-10|Strange Dogs|Season 6 opener.
+EOF2
+
+existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
+printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
+  [ -z "$season" ] && continue
+  if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
+    echo "Episode exists (S${season}): $title"
+  else
+    echo "Creating episode (S${season}): $title"
+    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+  fi
+  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
+  [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
+  for char in "James Holden" "Naomi Nagata" "Alex Kamal" "Amos Burton"; do
+    echo "  Linking $char"
+    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+  done
+done
+
+echo "The Expanse seeding complete"


### PR DESCRIPTION
## Summary
- add Farscape seeding script with seasons 1–4, main actors, characters, and opener episodes
- add The Expanse seeding script covering six seasons and key crew
- add Stargate Universe seeding script with actors, characters, and first episodes

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a783b04b4083218fe3cd8b25af9e7d