### PR TITLE
Link only appearing characters in episode seeds

### DIFF
--- a/seed_doctor_who.sh
+++ b/seed_doctor_who.sh
@@ -212,7 +212,7 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   # Companions (pipe-separated), iterate line-by-line
   case "$season" in
     1) COMP="Susan Foreman|Ian Chesterton|Barbara Wright" ;;
-    2) COMP="Ian Chesterton|Barbara Wright" ;;
+    2) COMP="Susan Foreman|Ian Chesterton|Barbara Wright" ;;
     7) COMP="Brigadier Lethbridge-Stewart" ;;
     11|12|13|14) COMP="Sarah Jane Smith" ;;
     15) COMP="Leela" ;;

--- a/seed_farscape.sh
+++ b/seed_farscape.sh
@@ -94,7 +94,15 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   fi
   EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
   [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
-  for char in John\ Crichton "Aeryn Sun" "Ka D'Argo" Chiana; do
+
+  case "$season" in
+    1) CHARS="John Crichton|Aeryn Sun|Ka D'Argo" ;;
+    2|3) CHARS="John Crichton|Aeryn Sun|Ka D'Argo|Chiana" ;;
+    4) CHARS="John Crichton|Chiana" ;;
+    *) CHARS="" ;;
+  esac
+  echo "$CHARS" | tr '|' '\n' | while IFS= read -r char; do
+    [ -z "$char" ] && continue
     echo "  Linking $char"
     curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
   done

--- a/seed_the_expanse.sh
+++ b/seed_the_expanse.sh
@@ -98,7 +98,13 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   fi
   EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
   [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
-  for char in "James Holden" "Naomi Nagata" "Alex Kamal" "Amos Burton"; do
+
+  case "$season" in
+    6) CHARS="James Holden|Naomi Nagata|Amos Burton" ;;
+    *) CHARS="James Holden|Naomi Nagata|Alex Kamal|Amos Burton" ;;
+  esac
+  echo "$CHARS" | tr '|' '\n' | while IFS= read -r char; do
+    [ -z "$char" ] && continue
     echo "  Linking $char"
     curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
   done


### PR DESCRIPTION
## Summary
- Refine Doctor Who seeding to include Susan Foreman in season 2 opener
- Limit Farscape seeding to characters actually present in each season premiere
- Exclude Alex Kamal from The Expanse season 6 premiere character links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `apt-get update` *(fails: repository signatures forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a78adde3b08321a79d3ccd66376da0