### PR TITLE
feat: upsert on seed data

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -35,6 +35,7 @@ CREATE TABLE IF NOT EXISTS episodes (
   title VARCHAR(255) NOT NULL,
   description TEXT,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_episode_per_season (season_id, title),
   KEY idx_episodes_season (season_id),
   CONSTRAINT fk_episodes_season FOREIGN KEY (season_id) REFERENCES seasons(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
- make POST endpoints perform upserts so rerunning seed scripts replaces existing data
- enforce per-season unique episode titles to enable upsert

## Testing
- `node --check server.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a78bdf191883219a49c9d053a942a5