### PR TITLE
Seed three episodes per season with character links

### DIFF
--- a/seed_farscape.sh
+++ b/seed_farscape.sh
@@ -76,35 +76,35 @@ printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
   fi
 done
 
-read -r -d '' EPISODES <<'EOF2' || true
-1|1999-03-19|Premiere|Series premiere.
-2|2000-03-17|Mind the Baby|Season 2 opener.
-3|2001-03-16|Season of Death|Season 3 opener.
-4|2002-06-07|Crichton Kicks|Season 4 opener.
-EOF2
-
-existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
-printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
+# --- create 3 episodes per season ---
+printf '%s\n' "$SEASONS" | while IFS='|' read -r season year; do
   [ -z "$season" ] && continue
-  if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
-    echo "Episode exists (S${season}): $title"
-  else
-    echo "Creating episode (S${season}): $title"
-    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
-  fi
-  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
-  [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
+  eps=$(curl -s "$API/shows/$SHOW_ID/seasons/$season/episodes")
+  for ep in 1 2 3; do
+    title="S${season}E${ep}"
+    air_date=$(printf "%s-01-%02d" "$year" $((ep*7-6)))
+    description="Episode ${ep} of season ${season}."
+    if echo "$eps" | jq -e --arg t "$title" 'map(.title)|index($t)' >/dev/null; then
+      echo "Episode exists (S${season}E${ep}): $title"
+    else
+      echo "Creating episode (S${season}E${ep}): $title"
+      jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+      eps=$(curl -s "$API/shows/$SHOW_ID/seasons/$season/episodes")
+    fi
+    EP_ID=$(echo "$eps" | jq -r --arg t "$title" 'map(select(.title==$t)) | (.[0].id // empty)')
+    [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
 
-  case "$season" in
-    1) CHARS="John Crichton|Aeryn Sun|Ka D'Argo" ;;
-    2|3) CHARS="John Crichton|Aeryn Sun|Ka D'Argo|Chiana" ;;
-    4) CHARS="John Crichton|Chiana" ;;
-    *) CHARS="" ;;
-  esac
-  echo "$CHARS" | tr '|' '\n' | while IFS= read -r char; do
-    [ -z "$char" ] && continue
-    echo "  Linking $char"
-    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+    case "$season" in
+      1) CHARS="John Crichton|Aeryn Sun|Ka D'Argo" ;;
+      2|3) CHARS="John Crichton|Aeryn Sun|Ka D'Argo|Chiana" ;;
+      4) CHARS="John Crichton|Chiana" ;;
+      *) CHARS="" ;;
+    esac
+    echo "$CHARS" | tr '|' '\n' | while IFS= read -r char; do
+      [ -z "$char" ] && continue
+      echo "  Linking $char"
+      curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+    done
   done
 done
 

--- a/seed_stargate_universe.sh
+++ b/seed_stargate_universe.sh
@@ -74,25 +74,27 @@ printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
   fi
 done
 
-read -r -d '' EPISODES <<'EOF2' || true
-1|2009-10-02|Air (Part 1)|Series premiere.
-2|2010-09-28|Intervention|Season 2 opener.
-EOF2
-
-existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
-printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
+# --- create 3 episodes per season ---
+printf '%s\n' "$SEASONS" | while IFS='|' read -r season year; do
   [ -z "$season" ] && continue
-  if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
-    echo "Episode exists (S${season}): $title"
-  else
-    echo "Creating episode (S${season}): $title"
-    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
-  fi
-  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
-  [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
-  for char in "Dr. Nicholas Rush" "Col. Everett Young" "Eli Wallace" "Chloe Armstrong"; do
-    echo "  Linking $char"
-    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+  eps=$(curl -s "$API/shows/$SHOW_ID/seasons/$season/episodes")
+  for ep in 1 2 3; do
+    title="S${season}E${ep}"
+    air_date=$(printf "%s-01-%02d" "$year" $((ep*7-6)))
+    description="Episode ${ep} of season ${season}."
+    if echo "$eps" | jq -e --arg t "$title" 'map(.title)|index($t)' >/dev/null; then
+      echo "Episode exists (S${season}E${ep}): $title"
+    else
+      echo "Creating episode (S${season}E${ep}): $title"
+      jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+      eps=$(curl -s "$API/shows/$SHOW_ID/seasons/$season/episodes")
+    fi
+    EP_ID=$(echo "$eps" | jq -r --arg t "$title" 'map(select(.title==$t)) | (.[0].id // empty)')
+    [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
+    for char in "Dr. Nicholas Rush" "Col. Everett Young" "Eli Wallace" "Chloe Armstrong"; do
+      echo "  Linking $char"
+      curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+    done
   done
 done
 

--- a/seed_the_expanse.sh
+++ b/seed_the_expanse.sh
@@ -78,35 +78,33 @@ printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
   fi
 done
 
-read -r -d '' EPISODES <<'EOF2' || true
-1|2015-12-14|Dulcinea|Series premiere.
-2|2017-02-01|Safe|Season 2 opener.
-3|2018-04-11|Fight or Flight|Season 3 opener.
-4|2019-12-13|New Terra|Season 4 opener.
-5|2020-12-16|Exodus|Season 5 opener.
-6|2021-12-10|Strange Dogs|Season 6 opener.
-EOF2
-
-existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
-printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
+# --- create 3 episodes per season ---
+printf '%s\n' "$SEASONS" | while IFS='|' read -r season year; do
   [ -z "$season" ] && continue
-  if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
-    echo "Episode exists (S${season}): $title"
-  else
-    echo "Creating episode (S${season}): $title"
-    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
-  fi
-  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
-  [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
+  eps=$(curl -s "$API/shows/$SHOW_ID/seasons/$season/episodes")
+  for ep in 1 2 3; do
+    title="S${season}E${ep}"
+    air_date=$(printf "%s-01-%02d" "$year" $((ep*7-6)))
+    description="Episode ${ep} of season ${season}."
+    if echo "$eps" | jq -e --arg t "$title" 'map(.title)|index($t)' >/dev/null; then
+      echo "Episode exists (S${season}E${ep}): $title"
+    else
+      echo "Creating episode (S${season}E${ep}): $title"
+      jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+      eps=$(curl -s "$API/shows/$SHOW_ID/seasons/$season/episodes")
+    fi
+    EP_ID=$(echo "$eps" | jq -r --arg t "$title" 'map(select(.title==$t)) | (.[0].id // empty)')
+    [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
 
-  case "$season" in
-    6) CHARS="James Holden|Naomi Nagata|Amos Burton" ;;
-    *) CHARS="James Holden|Naomi Nagata|Alex Kamal|Amos Burton" ;;
-  esac
-  echo "$CHARS" | tr '|' '\n' | while IFS= read -r char; do
-    [ -z "$char" ] && continue
-    echo "  Linking $char"
-    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+    case "$season" in
+      6) CHARS="James Holden|Naomi Nagata|Amos Burton" ;;
+      *) CHARS="James Holden|Naomi Nagata|Alex Kamal|Amos Burton" ;;
+    esac
+    echo "$CHARS" | tr '|' '\n' | while IFS= read -r char; do
+      [ -z "$char" ] && continue
+      echo "  Linking $char"
+      curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+    done
   done
 done
 


### PR DESCRIPTION
## Summary
- ensure seeding scripts create three episodes for every season of Doctor Who, Farscape, Stargate Universe, and The Expanse
- link each generated episode to the appropriate characters

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68aa5c4d1fbc832191511080e7852a42