### PR TITLE
Seed scripts add placeholder episodes 4 and 5

### DIFF
--- a/seed_doctor_who.sh
+++ b/seed_doctor_who.sh
@@ -229,11 +229,11 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   fi
 done
 
-# --- create placeholder episodes to reach three per season ---
+# --- create placeholder episodes to reach five per season ---
 echo "Ensuring additional episodes..."
 for season in $(seq 1 26); do
   y="$(lookup_year "$season" || true)"
-  for ep in 2 3; do
+  for ep in 2 3 4 5; do
     title="S${season}E${ep}"
     air_date=$(printf "%s-01-%02d" "$y" $((ep*7-6)))
     description="Episode ${ep} of season ${season}."

--- a/seed_farscape.sh
+++ b/seed_farscape.sh
@@ -109,10 +109,10 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   done
 done
 
-# --- create additional episodes to reach three per season ---
+# --- create additional episodes to reach five per season ---
 printf '%s\n' "$SEASONS" | while IFS='|' read -r season year; do
   [ -z "$season" ] && continue
-  for ep in 2 3; do
+  for ep in 2 3 4 5; do
     title="S${season}E${ep}"
     air_date=$(printf "%s-01-%02d" "$year" $((ep*7-6)))
     description="Episode ${ep} of season ${season}."

--- a/seed_stargate_universe.sh
+++ b/seed_stargate_universe.sh
@@ -97,10 +97,10 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   done
 done
 
-# --- create additional episodes to reach three per season ---
+# --- create additional episodes to reach five per season ---
 printf '%s\n' "$SEASONS" | while IFS='|' read -r season year; do
   [ -z "$season" ] && continue
-  for ep in 2 3; do
+  for ep in 2 3 4 5; do
     title="S${season}E${ep}"
     air_date=$(printf "%s-01-%02d" "$year" $((ep*7-6)))
     description="Episode ${ep} of season ${season}."

--- a/seed_the_expanse.sh
+++ b/seed_the_expanse.sh
@@ -111,10 +111,10 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   done
 done
 
-# --- create additional episodes to reach three per season ---
+# --- create additional episodes to reach five per season ---
 printf '%s\n' "$SEASONS" | while IFS='|' read -r season year; do
   [ -z "$season" ] && continue
-  for ep in 2 3; do
+  for ep in 2 3 4 5; do
     title="S${season}E${ep}"
     air_date=$(printf "%s-01-%02d" "$year" $((ep*7-6)))
     description="Episode ${ep} of season ${season}."


### PR DESCRIPTION
## Summary
- extend seeding logic to generate placeholder episodes 4 and 5 for every season across all show seed scripts
- update script comments to reflect five episodes per season

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aa69ad985483219b535517facd86e5