### PR TITLE
Add Airbyte manifest for custom TVDB connector

### DIFF
--- a/airbyte_manifest.yaml
+++ b/airbyte_manifest.yaml
@@ -1,0 +1,135 @@
+version: "0.1.0"
+type: DeclarativeSource
+
+check:
+  type: CheckStream
+  stream_names:
+    - shows
+
+spec:
+  type: Spec
+  connection_specification:
+    $schema: http://json-schema.org/draft-07/schema#
+    title: TVDB Source Spec
+    type: object
+    required:
+      - api_url
+    properties:
+      api_url:
+        type: string
+        description: Base URL of the TVDB API.
+
+definitions:
+  base_requester:
+    type: HttpRequester
+    url_base: "{{ config['api_url'] }}"
+  streams:
+    shows:
+      type: DeclarativeStream
+      name: shows
+      primary_key: id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /shows
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: http://json-schema.org/draft-07/schema#
+          type: object
+          properties:
+            id:
+              type: integer
+            title:
+              type: string
+            description:
+              type: string
+            year:
+              type: integer
+          required:
+            - id
+            - title
+    seasons:
+      type: DeclarativeStream
+      name: seasons
+      primary_key: id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /seasons
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: http://json-schema.org/draft-07/schema#
+          type: object
+          properties:
+            id:
+              type: integer
+            show_id:
+              type: integer
+            season_number:
+              type: integer
+            year:
+              type: integer
+          required:
+            - id
+            - show_id
+            - season_number
+    episodes:
+      type: DeclarativeStream
+      name: episodes
+      primary_key: id
+      retriever:
+        type: SimpleRetriever
+        requester:
+          $ref: "#/definitions/base_requester"
+          path: /episodes
+          http_method: GET
+        record_selector:
+          type: RecordSelector
+          extractor:
+            type: DpathExtractor
+            field_path: []
+      schema_loader:
+        type: InlineSchemaLoader
+        schema:
+          $schema: http://json-schema.org/draft-07/schema#
+          type: object
+          properties:
+            id:
+              type: integer
+            show_id:
+              type: integer
+            season_id:
+              type: integer
+            title:
+              type: string
+            description:
+              type: string
+            air_date:
+              type: string
+              format: date
+          required:
+            - id
+            - show_id
+            - season_id
+            - title
+
+streams:
+  - $ref: "#/definitions/streams/shows"
+  - $ref: "#/definitions/streams/seasons"
+  - $ref: "#/definitions/streams/episodes"


### PR DESCRIPTION
## Summary
- add Airbyte declarative manifest describing shows, seasons, and episodes streams for the TVDB API

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa8c837314832199f86d94d89c8595