### PR TITLE
Add Postman collection

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1,0 +1,606 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "TV Shows API",
+    "version": "1.0.5",
+    "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
+  },
+  "servers": [
+    {
+      "url": "http://localhost:3000"
+    }
+  ],
+  "tags": [
+    {
+      "name": "health"
+    },
+    {
+      "name": "actors"
+    },
+    {
+      "name": "shows"
+    },
+    {
+      "name": "seasons"
+    },
+    {
+      "name": "episodes"
+    },
+    {
+      "name": "characters"
+    },
+    {
+      "name": "links"
+    },
+    {
+      "name": "jobs"
+    }
+  ],
+  "components": {
+    "schemas": {
+      "Actor": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "Show": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "year": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "Season": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "show_id": {
+            "type": "integer"
+          },
+          "season_number": {
+            "type": "integer"
+          },
+          "year": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "Episode": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "season_id": {
+            "type": "integer"
+          },
+          "show_id": {
+            "type": "integer"
+          },
+          "air_date": {
+            "type": "string",
+            "format": "date",
+            "nullable": true
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "Character": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "show_id": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "actor_id": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "JobStatus": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "eta_ms": {
+            "type": "integer"
+          },
+          "download_url": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      }
+    }
+  },
+  "paths": {
+    "/health": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Service/DB health",
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
+      }
+    },
+    "/init": {
+      "post": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Initialize DB/schema",
+        "responses": {
+          "200": {
+            "description": "Initialized"
+          }
+        }
+      }
+    },
+    "/actors": {
+      "get": {
+        "tags": [
+          "actors"
+        ],
+        "summary": "List actors"
+      },
+      "post": {
+        "tags": [
+          "actors"
+        ],
+        "summary": "Create actor"
+      }
+    },
+    "/actors/{id}": {
+      "get": {
+        "tags": [
+          "actors"
+        ],
+        "summary": "Get actor"
+      },
+      "put": {
+        "tags": [
+          "actors"
+        ],
+        "summary": "Update actor"
+      },
+      "delete": {
+        "tags": [
+          "actors"
+        ],
+        "summary": "Delete actor"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/shows": {
+      "get": {
+        "tags": [
+          "shows"
+        ],
+        "summary": "List shows"
+      },
+      "post": {
+        "tags": [
+          "shows"
+        ],
+        "summary": "Create show"
+      }
+    },
+    "/shows/{id}": {
+      "get": {
+        "tags": [
+          "shows"
+        ],
+        "summary": "Get show"
+      },
+      "put": {
+        "tags": [
+          "shows"
+        ],
+        "summary": "Update show"
+      },
+      "delete": {
+        "tags": [
+          "shows"
+        ],
+        "summary": "Delete show"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/shows/{showId}/seasons": {
+      "get": {
+        "tags": [
+          "seasons"
+        ],
+        "summary": "List seasons for show"
+      },
+      "post": {
+        "tags": [
+          "seasons"
+        ],
+        "summary": "Create season for show"
+      },
+      "parameters": [
+        {
+          "name": "showId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/seasons/{id}": {
+      "get": {
+        "tags": [
+          "seasons"
+        ],
+        "summary": "Get season"
+      },
+      "put": {
+        "tags": [
+          "seasons"
+        ],
+        "summary": "Update season"
+      },
+      "delete": {
+        "tags": [
+          "seasons"
+        ],
+        "summary": "Delete season"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/shows/{showId}/episodes": {
+      "get": {
+        "tags": [
+          "episodes"
+        ],
+        "summary": "List episodes for show"
+      },
+      "post": {
+        "tags": [
+          "episodes"
+        ],
+        "summary": "Create episode under a season by season_number"
+      },
+      "parameters": [
+        {
+          "name": "showId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/episodes/{id}": {
+      "get": {
+        "tags": [
+          "episodes"
+        ],
+        "summary": "Get episode (includes characters array)"
+      },
+      "put": {
+        "tags": [
+          "episodes"
+        ],
+        "summary": "Update episode"
+      },
+      "delete": {
+        "tags": [
+          "episodes"
+        ],
+        "summary": "Delete episode"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/shows/{showId}/characters": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "List characters for show"
+      },
+      "post": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Create character for show"
+      },
+      "parameters": [
+        {
+          "name": "showId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/characters/{id}": {
+      "get": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Get character"
+      },
+      "put": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Update character"
+      },
+      "delete": {
+        "tags": [
+          "characters"
+        ],
+        "summary": "Delete character"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/episodes/{episodeId}/characters": {
+      "get": {
+        "tags": [
+          "links"
+        ],
+        "summary": "List characters in episode"
+      },
+      "post": {
+        "tags": [
+          "links"
+        ],
+        "summary": "Link (or create+link) character to episode"
+      },
+      "parameters": [
+        {
+          "name": "episodeId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/episodes/{episodeId}/characters/{characterId}": {
+      "delete": {
+        "tags": [
+          "links"
+        ],
+        "summary": "Unlink character from episode"
+      },
+      "parameters": [
+        {
+          "name": "episodeId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        },
+        {
+          "name": "characterId",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "integer"
+          }
+        }
+      ]
+    },
+    "/shows/query-jobs": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Start simulated long‑running TV show query"
+      }
+    },
+    "/seasons/query-jobs": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Start simulated long‑running season query"
+      }
+    },
+    "/episodes/query-jobs": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Start simulated long‑running episode query"
+      }
+    },
+    "/characters/query-jobs": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Start simulated long‑running character query"
+      }
+    },
+    "/actors/query-jobs": {
+      "post": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Start simulated long‑running actor query"
+      }
+    },
+    "/jobs/{id}": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Poll job status"
+      },
+      "delete": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Delete job"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/jobs/{id}/download": {
+      "get": {
+        "tags": [
+          "jobs"
+        ],
+        "summary": "Download job results (JSON)"
+      },
+      "parameters": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "schema": {
+            "type": "string"
+          }
+        }
+      ]
+    },
+    "/seasons/{id}/episodes": {
+      "get": {
+        "tags": [
+          "episodes"
+        ],
+        "summary": "List episodes for a specific season",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
+      }
+    },
+    "/shows/{showId}/seasons/{seasonNumber}/episodes": {
+      "get": {
+        "tags": [
+          "episodes"
+        ],
+        "summary": "List episodes by show+season_number",
+        "parameters": [
+          {
+            "name": "showId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "seasonNumber",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/scripts/generate-postman.js
+++ b/scripts/generate-postman.js
@@ -1,0 +1,49 @@
+const fs = require('fs');
+const path = require('path');
+
+const specPath = path.resolve(__dirname, '..', 'openapi.json');
+const spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
+const baseUrl = (spec.servers && spec.servers[0] && spec.servers[0].url) || '';
+const url = new URL(baseUrl || 'http://localhost');
+
+const collection = {
+  info: {
+    name: spec.info && spec.info.title ? spec.info.title : 'API',
+    description: spec.info && spec.info.description ? spec.info.description : '',
+    version: spec.info && spec.info.version ? spec.info.version : '1.0.0',
+    schema: 'https://schema.getpostman.com/json/collection/v2.1.0/collection.json'
+  },
+  item: []
+};
+
+// Group items by first tag
+const folders = {};
+
+for (const [route, methods] of Object.entries(spec.paths || {})) {
+  for (const [method, op] of Object.entries(methods)) {
+    const tag = (op.tags && op.tags[0]) || 'default';
+    if (!folders[tag]) {
+      folders[tag] = { name: tag, item: [] };
+      collection.item.push(folders[tag]);
+    }
+    const item = {
+      name: `${method.toUpperCase()} ${route}`,
+      request: {
+        method: method.toUpperCase(),
+        url: {
+          raw: baseUrl + route,
+          protocol: url.protocol.replace(':', ''),
+          host: url.hostname.split('.'),
+          port: url.port || undefined,
+          path: route.split('/').filter(Boolean)
+        },
+        description: op.summary || ''
+      }
+    };
+    folders[tag].item.push(item);
+  }
+}
+
+const outPath = path.resolve(__dirname, '..', 'tvdb.postman_collection.json');
+fs.writeFileSync(outPath, JSON.stringify(collection, null, 2));
+console.log('Postman collection written to', outPath);

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -1,0 +1,1059 @@
+{
+  "info": {
+    "name": "TV Shows API",
+    "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
+    "version": "1.0.5",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "health",
+      "item": [
+        {
+          "name": "GET /health",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            },
+            "description": "Service/DB health"
+          }
+        },
+        {
+          "name": "POST /init",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/init",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "init"
+              ]
+            },
+            "description": "Initialize DB/schema"
+          }
+        }
+      ]
+    },
+    {
+      "name": "actors",
+      "item": [
+        {
+          "name": "GET /actors",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/actors",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors"
+              ]
+            },
+            "description": "List actors"
+          }
+        },
+        {
+          "name": "POST /actors",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/actors",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors"
+              ]
+            },
+            "description": "Create actor"
+          }
+        },
+        {
+          "name": "GET /actors/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
+            "description": "Get actor"
+          }
+        },
+        {
+          "name": "PUT /actors/{id}",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
+            "description": "Update actor"
+          }
+        },
+        {
+          "name": "DELETE /actors/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
+            "description": "Delete actor"
+          }
+        }
+      ]
+    },
+    {
+      "name": "default",
+      "item": [
+        {
+          "name": "PARAMETERS /actors/{id}",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /shows/{id}",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /shows/{showId}/seasons",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /seasons/{id}",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /shows/{showId}/episodes",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "episodes"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /episodes/{id}",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /shows/{showId}/characters",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "characters"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /characters/{id}",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /episodes/{episodeId}/characters",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /episodes/{episodeId}/characters/{characterId}",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters/{characterId}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters",
+                "{characterId}"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /jobs/{id}",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}"
+              ]
+            },
+            "description": ""
+          }
+        },
+        {
+          "name": "PARAMETERS /jobs/{id}/download",
+          "request": {
+            "method": "PARAMETERS",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}/download",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}",
+                "download"
+              ]
+            },
+            "description": ""
+          }
+        }
+      ]
+    },
+    {
+      "name": "shows",
+      "item": [
+        {
+          "name": "GET /shows",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/shows",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows"
+              ]
+            },
+            "description": "List shows"
+          }
+        },
+        {
+          "name": "POST /shows",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/shows",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows"
+              ]
+            },
+            "description": "Create show"
+          }
+        },
+        {
+          "name": "GET /shows/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
+            "description": "Get show"
+          }
+        },
+        {
+          "name": "PUT /shows/{id}",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
+            "description": "Update show"
+          }
+        },
+        {
+          "name": "DELETE /shows/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
+            "description": "Delete show"
+          }
+        }
+      ]
+    },
+    {
+      "name": "seasons",
+      "item": [
+        {
+          "name": "GET /shows/{showId}/seasons",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons"
+              ]
+            },
+            "description": "List seasons for show"
+          }
+        },
+        {
+          "name": "POST /shows/{showId}/seasons",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons"
+              ]
+            },
+            "description": "Create season for show"
+          }
+        },
+        {
+          "name": "GET /seasons/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
+            "description": "Get season"
+          }
+        },
+        {
+          "name": "PUT /seasons/{id}",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
+            "description": "Update season"
+          }
+        },
+        {
+          "name": "DELETE /seasons/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
+            "description": "Delete season"
+          }
+        }
+      ]
+    },
+    {
+      "name": "episodes",
+      "item": [
+        {
+          "name": "GET /shows/{showId}/episodes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "episodes"
+              ]
+            },
+            "description": "List episodes for show"
+          }
+        },
+        {
+          "name": "POST /shows/{showId}/episodes",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "episodes"
+              ]
+            },
+            "description": "Create episode under a season by season_number"
+          }
+        },
+        {
+          "name": "GET /episodes/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
+            "description": "Get episode (includes characters array)"
+          }
+        },
+        {
+          "name": "PUT /episodes/{id}",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
+            "description": "Update episode"
+          }
+        },
+        {
+          "name": "DELETE /episodes/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
+            "description": "Delete episode"
+          }
+        },
+        {
+          "name": "GET /seasons/{id}/episodes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}",
+                "episodes"
+              ]
+            },
+            "description": "List episodes for a specific season"
+          }
+        },
+        {
+          "name": "GET /shows/{showId}/seasons/{seasonNumber}/episodes",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons/{seasonNumber}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons",
+                "{seasonNumber}",
+                "episodes"
+              ]
+            },
+            "description": "List episodes by show+season_number"
+          }
+        }
+      ]
+    },
+    {
+      "name": "characters",
+      "item": [
+        {
+          "name": "GET /shows/{showId}/characters",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "characters"
+              ]
+            },
+            "description": "List characters for show"
+          }
+        },
+        {
+          "name": "POST /shows/{showId}/characters",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "characters"
+              ]
+            },
+            "description": "Create character for show"
+          }
+        },
+        {
+          "name": "GET /characters/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
+            "description": "Get character"
+          }
+        },
+        {
+          "name": "PUT /characters/{id}",
+          "request": {
+            "method": "PUT",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
+            "description": "Update character"
+          }
+        },
+        {
+          "name": "DELETE /characters/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
+            "description": "Delete character"
+          }
+        }
+      ]
+    },
+    {
+      "name": "links",
+      "item": [
+        {
+          "name": "GET /episodes/{episodeId}/characters",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters"
+              ]
+            },
+            "description": "List characters in episode"
+          }
+        },
+        {
+          "name": "POST /episodes/{episodeId}/characters",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters"
+              ]
+            },
+            "description": "Link (or create+link) character to episode"
+          }
+        },
+        {
+          "name": "DELETE /episodes/{episodeId}/characters/{characterId}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters/{characterId}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters",
+                "{characterId}"
+              ]
+            },
+            "description": "Unlink character from episode"
+          }
+        }
+      ]
+    },
+    {
+      "name": "jobs",
+      "item": [
+        {
+          "name": "POST /shows/query-jobs",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/shows/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "query-jobs"
+              ]
+            },
+            "description": "Start simulated long‑running TV show query"
+          }
+        },
+        {
+          "name": "POST /seasons/query-jobs",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/seasons/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "query-jobs"
+              ]
+            },
+            "description": "Start simulated long‑running season query"
+          }
+        },
+        {
+          "name": "POST /episodes/query-jobs",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/episodes/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "query-jobs"
+              ]
+            },
+            "description": "Start simulated long‑running episode query"
+          }
+        },
+        {
+          "name": "POST /characters/query-jobs",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/characters/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "query-jobs"
+              ]
+            },
+            "description": "Start simulated long‑running character query"
+          }
+        },
+        {
+          "name": "POST /actors/query-jobs",
+          "request": {
+            "method": "POST",
+            "url": {
+              "raw": "http://localhost:3000/actors/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "query-jobs"
+              ]
+            },
+            "description": "Start simulated long‑running actor query"
+          }
+        },
+        {
+          "name": "GET /jobs/{id}",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}"
+              ]
+            },
+            "description": "Poll job status"
+          }
+        },
+        {
+          "name": "DELETE /jobs/{id}",
+          "request": {
+            "method": "DELETE",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}"
+              ]
+            },
+            "description": "Delete job"
+          }
+        },
+        {
+          "name": "GET /jobs/{id}/download",
+          "request": {
+            "method": "GET",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}/download",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}",
+                "download"
+              ]
+            },
+            "description": "Download job results (JSON)"
+          }
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- extract OpenAPI definition into `openapi.json`
- generate Postman collection with script and commit `tvdb.postman_collection.json`
- add `scripts/generate-postman.js` to recreate the collection from the OpenAPI spec

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ba7e9b948321a0f6e35a9f7876cb