### PR TITLE
Add basic GraphQL endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project implements:
 - Simulated long-running job queries with polling + downloadable results
 - Auto DB initialization on start (runs `schema.sql`)
 - **API discovery** via OpenAPI at `/openapi.json` (+ optional Swagger UI at `/docs`)
+- **GraphQL endpoint** at `/graphql` mirroring CRUD operations and jobs
+- **GraphQL discovery** at `/graphql.json` (also `/.well-known/graphql.json`)
 - **Season episodes endpoints:** `GET /seasons/:id/episodes` and `GET /shows/:showId/seasons/:seasonNumber/episodes`
 
 ## Quick start
@@ -45,6 +47,31 @@ curl -s "$API/health" | jq .
 curl -s "$API/openapi.json" | jq .info
 curl -s "$API/spec" | jq .info
 curl -s "$API/.well-known/openapi.json" | jq .info
+```
+
+### GraphQL discovery
+```bash
+curl -s "$API/graphql.json" | jq .
+curl -s "$API/.well-known/graphql.json" | jq .
+```
+
+### GraphQL queries
+All REST functionality is also exposed via a lightweight GraphQL endpoint at `/graphql`.
+```bash
+# Health check
+curl -s -X POST "$API/graphql" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ health { ok db } }"}' | jq .
+
+# Create an actor via mutation
+curl -s -X POST "$API/graphql" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"mutation { createActor(name:\"Sarah Jane\") { id name } }"}' | jq .
+
+# Fetch a show with nested seasons and episodes
+curl -s -X POST "$API/graphql" \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"{ show(id:1) { title seasons { season_number episodes { title } } } }"}' | jq .
 ```
 
 ### Actors

--- a/test/graphql.test.js
+++ b/test/graphql.test.js
@@ -1,0 +1,61 @@
+const { test, before, after } = require('node:test');
+const assert = require('node:assert');
+const { spawn } = require('node:child_process');
+const path = require('node:path');
+
+let serverProcess;
+
+before(async () => {
+  const mockPath = path.resolve(__dirname, 'mock-db.js');
+  serverProcess = spawn('node', ['-r', mockPath, 'server.js'], {
+    cwd: __dirname + '/..',
+    env: { ...process.env, PORT: '3001' },
+    stdio: ['ignore', 'pipe', 'pipe']
+  });
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('server start timeout')), 10000);
+    serverProcess.stdout.on('data', (data) => {
+      if (data.toString().includes('API listening')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    serverProcess.on('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error('server exited with code ' + code));
+    });
+  });
+});
+
+after(() => {
+  if (serverProcess) serverProcess.kill();
+});
+
+test('GraphQL discovery', async () => {
+  const res = await fetch('http://localhost:3001/graphql.json');
+  const json = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.ok(json.operations && json.operations.health);
+});
+
+test('GraphQL health', async () => {
+  const res = await fetch('http://localhost:3001/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: '{ health { ok db } }' })
+  });
+  const json = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.ok(json.data && json.data.health);
+});
+
+test('GraphQL createActor', async () => {
+  const res = await fetch('http://localhost:3001/graphql', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ query: 'mutation { createActor(name:"Tester"){ id name } }' })
+  });
+  const json = await res.json();
+  assert.strictEqual(res.status, 200);
+  assert.ok('createActor' in json.data);
+});


### PR DESCRIPTION
## Summary
- add lightweight GraphQL layer with resolvers mirroring REST CRUD and job operations
- expose `/graphql` endpoint with simple parser to handle queries and mutations
- cover new GraphQL endpoint with tests
- document GraphQL usage with cURL examples
- expose GraphQL discovery metadata at `/graphql.json` and `/.well-known/graphql.json`
- document GraphQL discovery and test it

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b85cf129008321aed7ff5a97d31f7b