### PR TITLE
chore: release 1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.7] - 2025-09-03
+### Added
+- GraphQL endpoints mirroring existing REST resources.
+- Exposed GraphQL discovery endpoint.
+### Changed
+- Bumped package, Postman collection, and spec versions to 1.0.7.
+
 ## [1.0.6] - 2025-08-28
 ### Added
 - Support for nested sub-resource retrieval via `include` parameter.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,8 +18,8 @@ services:
       MYSQL_ROOT_PASSWORD: admin
     ports:
       - "6888:80"
-  tvdb:
-    image: ravelox/tvdb:1.0.6
+    tvdb:
+      image: ravelox/tvdb:1.0.7
     restart: always
     depends_on:
       - db

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -26,6 +26,7 @@ const fs = require('fs');
 const path = require('path');
 const { randomUUID } = require('crypto');
 require('dotenv').config();
+const pkg = require('./package.json');
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 const DB_HOST = process.env.DB_HOST || 'localhost';
@@ -108,7 +109,7 @@ const openapiBase = {
   openapi: '3.0.3',
   info: {
     title: 'TV Shows API',
-    version: '1.0.5',
+    version: pkg.version,
     description: 'CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.'
   },
   servers: [], // populated dynamically per request
@@ -1113,7 +1114,7 @@ app.get(['/graphql.json', '/.well-known/graphql.json'], (req, res) => {
   for (const [name, fn] of Object.entries(root)) {
     operations[name] = extractArgNames(fn);
   }
-  res.json({ operations });
+  res.json({ version: pkg.version, operations });
 });
 
 app.post('/graphql', asyncH(async (req, res) => {

--- a/test/graphql.test.js
+++ b/test/graphql.test.js
@@ -2,6 +2,7 @@ const { test, before, after } = require('node:test');
 const assert = require('node:assert');
 const { spawn } = require('node:child_process');
 const path = require('node:path');
+const pkg = require('../package.json');
 
 let serverProcess;
 
@@ -35,6 +36,7 @@ test('GraphQL discovery', async () => {
   const res = await fetch('http://localhost:3001/graphql.json');
   const json = await res.json();
   assert.strictEqual(res.status, 200);
+  assert.strictEqual(json.version, pkg.version);
   assert.ok(json.operations && json.operations.health);
 });
 

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [


### PR DESCRIPTION
## Summary
- document GraphQL features in changelog
- bump application version to 1.0.7
- return correct version from GraphQL discovery and OpenAPI discovery

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b876c10e508321af850dad5fcd2721