### PR TITLE
chore: bump version to 1.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.8] - 2025-09-04
+### Changed
+- Bumped package, Docker Compose, Postman collection, and spec versions to 1.0.8.
+
 ## [1.0.7] - 2025-09-03
 ### Added
 - GraphQL endpoints mirroring existing REST resources.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
     ports:
       - "6888:80"
   tvdb:
-    image: ravelox/tvdb:1.0.7
+    image: ravelox/tvdb:1.0.8
     restart: always
     depends_on:
       - db

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.0.7",
+    "version": "1.0.8",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [


### PR DESCRIPTION
## Summary
- bump TV Shows API version to 1.0.8 across package, spec, docker image, and Postman collection
- record version bump in changelog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bf6d2c27508321a0304e4c1dd8f0ff