### PR TITLE
Ensure app waits for storage readiness

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,16 +3,23 @@ services:
     image: mysql:latest
     restart: always
     environment:
-      MYSQL_ROOT_PASSWORD: admin 
+      MYSQL_ROOT_PASSWORD: admin
     volumes:
       - mysql-data:/var/lib/mysql
     ports:
       - "3336:3306"
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
   phpmyadmin:
     image: phpmyadmin/phpmyadmin:latest
     restart: always
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
       PMA_HOST: db
       MYSQL_ROOT_PASSWORD: admin
@@ -22,7 +29,8 @@ services:
     image: ravelox/tvdb:latest
     restart: always
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     ports:
       - "3001:3000"
     environment:

--- a/k8s/tvdb-app-deployment.yaml
+++ b/k8s/tvdb-app-deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: tvdb
     spec:
+      initContainers:
+      - name: wait-for-storage
+        image: busybox:1.28
+        command: ['sh', '-c', 'until nc -zv tvdb-database 3306; do echo waiting for database; sleep 2; done']
       containers:
       - name: tvdb-app
         image: ravelox/tvdb:latest

--- a/k8s/tvdb-storage-deployment.yaml
+++ b/k8s/tvdb-storage-deployment.yaml
@@ -24,6 +24,11 @@ spec:
           value: admin
         ports:
         - containerPort: 3306
+        readinessProbe:
+          exec:
+            command: ["mysqladmin", "ping", "-h", "127.0.0.1"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
         volumeMounts:
         - name: tvdb-storage-volume
           mountPath: /var/lib/mysql


### PR DESCRIPTION
## Summary
- add MySQL healthcheck and depends_on conditions so tvdb service waits for healthy storage in Docker Compose
- add readiness probe to storage deployment and init container to app deployment to delay startup until storage is ready in Kubernetes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58f655b108321ab02c539f13fb3d3