### PR TITLE
feat: expand admin UI for all endpoints

### DIFF
--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>TVDB Admin</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    label { display: inline-block; width: 120px; }
+    form div { margin-bottom: 0.5rem; }
+    section { border: 1px solid #ccc; padding: 1rem; margin-bottom: 1rem; }
+    pre { background: #f0f0f0; padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>TVDB Admin</h1>
+  <div id="endpoints"></div>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,94 @@
+async function init() {
+  const spec = await fetch('/openapi.json').then(r => r.json());
+  const container = document.getElementById('endpoints');
+
+  for (const [path, ops] of Object.entries(spec.paths || {})) {
+    for (const [method, op] of Object.entries(ops)) {
+      const section = document.createElement('section');
+      const h3 = document.createElement('h3');
+      h3.textContent = `${method.toUpperCase()} ${path}`;
+      section.appendChild(h3);
+      const form = document.createElement('form');
+
+      // parameters (path & query)
+      for (const param of op.parameters || []) {
+        const div = document.createElement('div');
+        const label = document.createElement('label');
+        label.textContent = `${param.name} (${param.in})`;
+        label.htmlFor = `${method}_${path}_${param.name}`;
+        const input = document.createElement('input');
+        input.id = label.htmlFor;
+        input.name = param.name;
+        input.type = param.schema?.type === 'integer' ? 'number' : 'text';
+        div.appendChild(label);
+        div.appendChild(input);
+        form.appendChild(div);
+      }
+
+      // request body
+      if (op.requestBody?.content?.['application/json']) {
+        const div = document.createElement('div');
+        const label = document.createElement('label');
+        label.textContent = 'body (json)';
+        label.htmlFor = `${method}_${path}_body`;
+        const textarea = document.createElement('textarea');
+        textarea.id = label.htmlFor;
+        textarea.name = 'body';
+        textarea.rows = 4;
+        textarea.cols = 50;
+        div.appendChild(label);
+        div.appendChild(textarea);
+        form.appendChild(div);
+      }
+
+      const button = document.createElement('button');
+      button.type = 'submit';
+      button.textContent = 'Send';
+      form.appendChild(button);
+
+      const pre = document.createElement('pre');
+      form.appendChild(pre);
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        let url = path;
+        const query = new URLSearchParams();
+        let bodyText = null;
+        for (const el of form.elements) {
+          if (!el.name || el.type === 'submit') continue;
+          if (el.name === 'body') {
+            bodyText = el.value;
+            continue;
+          }
+          const param = (op.parameters || []).find(p => p.name === el.name);
+          if (!param) continue;
+          const value = el.type === 'number' && el.value ? Number(el.value) : el.value;
+          if (param.in === 'path') {
+            url = url.replace(`{${param.name}}`, encodeURIComponent(value));
+          } else if (param.in === 'query') {
+            query.append(param.name, value);
+          }
+        }
+        if (query.toString()) url += `?${query.toString()}`;
+        const options = { method: method.toUpperCase() };
+        if (bodyText !== null) {
+          try {
+            options.body = bodyText ? JSON.stringify(JSON.parse(bodyText)) : '';
+          } catch (err) {
+            pre.textContent = 'Invalid JSON body';
+            return;
+          }
+          options.headers = { 'Content-Type': 'application/json' };
+        }
+        const res = await fetch(url, options);
+        const text = await res.text();
+        pre.textContent = text;
+      });
+
+      section.appendChild(form);
+      container.appendChild(section);
+    }
+  }
+}
+
+init();

--- a/server.js
+++ b/server.js
@@ -62,6 +62,8 @@ let pool;
 const app = express();
 app.use(express.json());
 app.use(morgan('dev'));
+// simple admin web UI
+app.use('/admin', express.static(path.join(__dirname, 'public')));
 
 function httpError(res, code, message) { return res.status(code).json({ error: message }); }
 const asyncH = (fn) => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next);


### PR DESCRIPTION
## Summary
- generate admin interface for all API operations using OpenAPI spec
- support path/query parameters and optional JSON bodies per endpoint

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c590bcb7888321ba2a044e5ee89de2