### PR TITLE
feat: expand admin UI for all endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.9] - 2025-09-13
+### Changed
+- Prefixed all log output with the package version.
+- Bumped package, Postman collection, and spec versions to 1.0.9.
+
 ## [1.0.8] - 2025-09-04
 ### Changed
 - Bumped package, Docker Compose, Postman collection, and spec versions to 1.0.8.

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/public/admin.html
+++ b/public/admin.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>TVDB Admin</title>
+  <style>
+    body { font-family: sans-serif; margin: 2rem; }
+    label { display: inline-block; width: 120px; }
+    form div { margin-bottom: 0.5rem; }
+    section { border: 1px solid #ccc; padding: 1rem; margin-bottom: 1rem; }
+    pre { background: #f0f0f0; padding: 0.5rem; }
+  </style>
+</head>
+<body>
+  <h1>TVDB Admin</h1>
+  <div id="endpoints"></div>
+  <script src="admin.js"></script>
+</body>
+</html>

--- a/public/admin.js
+++ b/public/admin.js
@@ -1,0 +1,94 @@
+async function init() {
+  const spec = await fetch('/openapi.json').then(r => r.json());
+  const container = document.getElementById('endpoints');
+
+  for (const [path, ops] of Object.entries(spec.paths || {})) {
+    for (const [method, op] of Object.entries(ops)) {
+      const section = document.createElement('section');
+      const h3 = document.createElement('h3');
+      h3.textContent = `${method.toUpperCase()} ${path}`;
+      section.appendChild(h3);
+      const form = document.createElement('form');
+
+      // parameters (path & query)
+      for (const param of op.parameters || []) {
+        const div = document.createElement('div');
+        const label = document.createElement('label');
+        label.textContent = `${param.name} (${param.in})`;
+        label.htmlFor = `${method}_${path}_${param.name}`;
+        const input = document.createElement('input');
+        input.id = label.htmlFor;
+        input.name = param.name;
+        input.type = param.schema?.type === 'integer' ? 'number' : 'text';
+        div.appendChild(label);
+        div.appendChild(input);
+        form.appendChild(div);
+      }
+
+      // request body
+      if (op.requestBody?.content?.['application/json']) {
+        const div = document.createElement('div');
+        const label = document.createElement('label');
+        label.textContent = 'body (json)';
+        label.htmlFor = `${method}_${path}_body`;
+        const textarea = document.createElement('textarea');
+        textarea.id = label.htmlFor;
+        textarea.name = 'body';
+        textarea.rows = 4;
+        textarea.cols = 50;
+        div.appendChild(label);
+        div.appendChild(textarea);
+        form.appendChild(div);
+      }
+
+      const button = document.createElement('button');
+      button.type = 'submit';
+      button.textContent = 'Send';
+      form.appendChild(button);
+
+      const pre = document.createElement('pre');
+      form.appendChild(pre);
+
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        let url = path;
+        const query = new URLSearchParams();
+        let bodyText = null;
+        for (const el of form.elements) {
+          if (!el.name || el.type === 'submit') continue;
+          if (el.name === 'body') {
+            bodyText = el.value;
+            continue;
+          }
+          const param = (op.parameters || []).find(p => p.name === el.name);
+          if (!param) continue;
+          const value = el.type === 'number' && el.value ? Number(el.value) : el.value;
+          if (param.in === 'path') {
+            url = url.replace(`{${param.name}}`, encodeURIComponent(value));
+          } else if (param.in === 'query') {
+            query.append(param.name, value);
+          }
+        }
+        if (query.toString()) url += `?${query.toString()}`;
+        const options = { method: method.toUpperCase() };
+        if (bodyText !== null) {
+          try {
+            options.body = bodyText ? JSON.stringify(JSON.parse(bodyText)) : '';
+          } catch (err) {
+            pre.textContent = 'Invalid JSON body';
+            return;
+          }
+          options.headers = { 'Content-Type': 'application/json' };
+        }
+        const res = await fetch(url, options);
+        const text = await res.text();
+        pre.textContent = text;
+      });
+
+      section.appendChild(form);
+      container.appendChild(section);
+    }
+  }
+}
+
+init();

--- a/scripts/generate-postman.js
+++ b/scripts/generate-postman.js
@@ -1,5 +1,7 @@
 const fs = require('fs');
 const path = require('path');
+const pkg = require('../package.json');
+const log = (...args) => console.log(`[v${pkg.version}]`, ...args);
 
 const specPath = path.resolve(__dirname, '..', 'openapi.json');
 const spec = JSON.parse(fs.readFileSync(specPath, 'utf8'));
@@ -46,4 +48,4 @@ for (const [route, methods] of Object.entries(spec.paths || {})) {
 
 const outPath = path.resolve(__dirname, '..', 'tvdb.postman_collection.json');
 fs.writeFileSync(outPath, JSON.stringify(collection, null, 2));
-console.log('Postman collection written to', outPath);
+log('Postman collection written to', outPath);

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -13,7 +13,17 @@
           "name": "GET /health",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/health",
+            "url": {
+              "raw": "http://localhost:3000/health",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "health"
+              ]
+            },
             "description": "Service/DB health"
           }
         },
@@ -21,7 +31,17 @@
           "name": "POST /init",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/init",
+            "url": {
+              "raw": "http://localhost:3000/init",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "init"
+              ]
+            },
             "description": "Initialize DB/schema"
           }
         }
@@ -34,7 +54,17 @@
           "name": "GET /actors",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/actors",
+            "url": {
+              "raw": "http://localhost:3000/actors",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors"
+              ]
+            },
             "description": "List actors"
           }
         },
@@ -42,7 +72,17 @@
           "name": "POST /actors",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/actors",
+            "url": {
+              "raw": "http://localhost:3000/actors",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors"
+              ]
+            },
             "description": "Create actor"
           }
         },
@@ -50,7 +90,18 @@
           "name": "GET /actors/{id}",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/actors/{id}",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
             "description": "Get actor"
           }
         },
@@ -58,7 +109,18 @@
           "name": "PUT /actors/{id}",
           "request": {
             "method": "PUT",
-            "url": "{{baseUrl}}/actors/{id}",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
             "description": "Update actor"
           }
         },
@@ -66,7 +128,18 @@
           "name": "DELETE /actors/{id}",
           "request": {
             "method": "DELETE",
-            "url": "{{baseUrl}}/actors/{id}",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
             "description": "Delete actor"
           }
         }
@@ -79,7 +152,18 @@
           "name": "PARAMETERS /actors/{id}",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/actors/{id}",
+            "url": {
+              "raw": "http://localhost:3000/actors/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "{id}"
+              ]
+            },
             "description": ""
           }
         },
@@ -87,7 +171,18 @@
           "name": "PARAMETERS /shows/{id}",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/shows/{id}",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
             "description": ""
           }
         },
@@ -95,7 +190,19 @@
           "name": "PARAMETERS /shows/{showId}/seasons",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/shows/{showId}/seasons",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons"
+              ]
+            },
             "description": ""
           }
         },
@@ -103,7 +210,18 @@
           "name": "PARAMETERS /seasons/{id}",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/seasons/{id}",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
             "description": ""
           }
         },
@@ -111,7 +229,19 @@
           "name": "PARAMETERS /shows/{showId}/episodes",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/shows/{showId}/episodes",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "episodes"
+              ]
+            },
             "description": ""
           }
         },
@@ -119,7 +249,18 @@
           "name": "PARAMETERS /episodes/{id}",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/episodes/{id}",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
             "description": ""
           }
         },
@@ -127,7 +268,19 @@
           "name": "PARAMETERS /shows/{showId}/characters",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/shows/{showId}/characters",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "characters"
+              ]
+            },
             "description": ""
           }
         },
@@ -135,7 +288,18 @@
           "name": "PARAMETERS /characters/{id}",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/characters/{id}",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
             "description": ""
           }
         },
@@ -143,7 +307,19 @@
           "name": "PARAMETERS /episodes/{episodeId}/characters",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/episodes/{episodeId}/characters",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters"
+              ]
+            },
             "description": ""
           }
         },
@@ -151,7 +327,20 @@
           "name": "PARAMETERS /episodes/{episodeId}/characters/{characterId}",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/episodes/{episodeId}/characters/{characterId}",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters/{characterId}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters",
+                "{characterId}"
+              ]
+            },
             "description": ""
           }
         },
@@ -159,7 +348,18 @@
           "name": "PARAMETERS /jobs/{id}",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/jobs/{id}",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}"
+              ]
+            },
             "description": ""
           }
         },
@@ -167,7 +367,19 @@
           "name": "PARAMETERS /jobs/{id}/download",
           "request": {
             "method": "PARAMETERS",
-            "url": "{{baseUrl}}/jobs/{id}/download",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}/download",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}",
+                "download"
+              ]
+            },
             "description": ""
           }
         }
@@ -180,7 +392,17 @@
           "name": "GET /shows",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/shows",
+            "url": {
+              "raw": "http://localhost:3000/shows",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows"
+              ]
+            },
             "description": "List shows"
           }
         },
@@ -188,7 +410,17 @@
           "name": "POST /shows",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/shows",
+            "url": {
+              "raw": "http://localhost:3000/shows",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows"
+              ]
+            },
             "description": "Create show"
           }
         },
@@ -196,7 +428,18 @@
           "name": "GET /shows/{id}",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/shows/{id}",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
             "description": "Get show"
           }
         },
@@ -204,7 +447,18 @@
           "name": "PUT /shows/{id}",
           "request": {
             "method": "PUT",
-            "url": "{{baseUrl}}/shows/{id}",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
             "description": "Update show"
           }
         },
@@ -212,7 +466,18 @@
           "name": "DELETE /shows/{id}",
           "request": {
             "method": "DELETE",
-            "url": "{{baseUrl}}/shows/{id}",
+            "url": {
+              "raw": "http://localhost:3000/shows/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{id}"
+              ]
+            },
             "description": "Delete show"
           }
         }
@@ -225,7 +490,19 @@
           "name": "GET /shows/{showId}/seasons",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/shows/{showId}/seasons",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons"
+              ]
+            },
             "description": "List seasons for show"
           }
         },
@@ -233,7 +510,19 @@
           "name": "POST /shows/{showId}/seasons",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/shows/{showId}/seasons",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons"
+              ]
+            },
             "description": "Create season for show"
           }
         },
@@ -241,7 +530,18 @@
           "name": "GET /seasons/{id}",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/seasons/{id}",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
             "description": "Get season"
           }
         },
@@ -249,7 +549,18 @@
           "name": "PUT /seasons/{id}",
           "request": {
             "method": "PUT",
-            "url": "{{baseUrl}}/seasons/{id}",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
             "description": "Update season"
           }
         },
@@ -257,7 +568,18 @@
           "name": "DELETE /seasons/{id}",
           "request": {
             "method": "DELETE",
-            "url": "{{baseUrl}}/seasons/{id}",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}"
+              ]
+            },
             "description": "Delete season"
           }
         }
@@ -270,7 +592,19 @@
           "name": "GET /shows/{showId}/episodes",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/shows/{showId}/episodes",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "episodes"
+              ]
+            },
             "description": "List episodes for show"
           }
         },
@@ -278,7 +612,19 @@
           "name": "POST /shows/{showId}/episodes",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/shows/{showId}/episodes",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "episodes"
+              ]
+            },
             "description": "Create episode under a season by season_number"
           }
         },
@@ -286,7 +632,18 @@
           "name": "GET /episodes/{id}",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/episodes/{id}",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
             "description": "Get episode (includes characters array)"
           }
         },
@@ -294,7 +651,18 @@
           "name": "PUT /episodes/{id}",
           "request": {
             "method": "PUT",
-            "url": "{{baseUrl}}/episodes/{id}",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
             "description": "Update episode"
           }
         },
@@ -302,7 +670,18 @@
           "name": "DELETE /episodes/{id}",
           "request": {
             "method": "DELETE",
-            "url": "{{baseUrl}}/episodes/{id}",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{id}"
+              ]
+            },
             "description": "Delete episode"
           }
         },
@@ -310,7 +689,19 @@
           "name": "GET /seasons/{id}/episodes",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/seasons/{id}/episodes",
+            "url": {
+              "raw": "http://localhost:3000/seasons/{id}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "{id}",
+                "episodes"
+              ]
+            },
             "description": "List episodes for a specific season"
           }
         },
@@ -318,7 +709,21 @@
           "name": "GET /shows/{showId}/seasons/{seasonNumber}/episodes",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/shows/{showId}/seasons/{seasonNumber}/episodes",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/seasons/{seasonNumber}/episodes",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "seasons",
+                "{seasonNumber}",
+                "episodes"
+              ]
+            },
             "description": "List episodes by show+season_number"
           }
         }
@@ -331,7 +736,19 @@
           "name": "GET /shows/{showId}/characters",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/shows/{showId}/characters",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "characters"
+              ]
+            },
             "description": "List characters for show"
           }
         },
@@ -339,7 +756,19 @@
           "name": "POST /shows/{showId}/characters",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/shows/{showId}/characters",
+            "url": {
+              "raw": "http://localhost:3000/shows/{showId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "{showId}",
+                "characters"
+              ]
+            },
             "description": "Create character for show"
           }
         },
@@ -347,7 +776,18 @@
           "name": "GET /characters/{id}",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/characters/{id}",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
             "description": "Get character"
           }
         },
@@ -355,7 +795,18 @@
           "name": "PUT /characters/{id}",
           "request": {
             "method": "PUT",
-            "url": "{{baseUrl}}/characters/{id}",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
             "description": "Update character"
           }
         },
@@ -363,7 +814,18 @@
           "name": "DELETE /characters/{id}",
           "request": {
             "method": "DELETE",
-            "url": "{{baseUrl}}/characters/{id}",
+            "url": {
+              "raw": "http://localhost:3000/characters/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "{id}"
+              ]
+            },
             "description": "Delete character"
           }
         }
@@ -376,7 +838,19 @@
           "name": "GET /episodes/{episodeId}/characters",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/episodes/{episodeId}/characters",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters"
+              ]
+            },
             "description": "List characters in episode"
           }
         },
@@ -384,7 +858,19 @@
           "name": "POST /episodes/{episodeId}/characters",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/episodes/{episodeId}/characters",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters"
+              ]
+            },
             "description": "Link (or create+link) character to episode"
           }
         },
@@ -392,7 +878,20 @@
           "name": "DELETE /episodes/{episodeId}/characters/{characterId}",
           "request": {
             "method": "DELETE",
-            "url": "{{baseUrl}}/episodes/{episodeId}/characters/{characterId}",
+            "url": {
+              "raw": "http://localhost:3000/episodes/{episodeId}/characters/{characterId}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "{episodeId}",
+                "characters",
+                "{characterId}"
+              ]
+            },
             "description": "Unlink character from episode"
           }
         }
@@ -405,7 +904,18 @@
           "name": "POST /shows/query-jobs",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/shows/query-jobs",
+            "url": {
+              "raw": "http://localhost:3000/shows/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "shows",
+                "query-jobs"
+              ]
+            },
             "description": "Start simulated long‑running TV show query"
           }
         },
@@ -413,7 +923,18 @@
           "name": "POST /seasons/query-jobs",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/seasons/query-jobs",
+            "url": {
+              "raw": "http://localhost:3000/seasons/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "seasons",
+                "query-jobs"
+              ]
+            },
             "description": "Start simulated long‑running season query"
           }
         },
@@ -421,7 +942,18 @@
           "name": "POST /episodes/query-jobs",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/episodes/query-jobs",
+            "url": {
+              "raw": "http://localhost:3000/episodes/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "episodes",
+                "query-jobs"
+              ]
+            },
             "description": "Start simulated long‑running episode query"
           }
         },
@@ -429,7 +961,18 @@
           "name": "POST /characters/query-jobs",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/characters/query-jobs",
+            "url": {
+              "raw": "http://localhost:3000/characters/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "characters",
+                "query-jobs"
+              ]
+            },
             "description": "Start simulated long‑running character query"
           }
         },
@@ -437,7 +980,18 @@
           "name": "POST /actors/query-jobs",
           "request": {
             "method": "POST",
-            "url": "{{baseUrl}}/actors/query-jobs",
+            "url": {
+              "raw": "http://localhost:3000/actors/query-jobs",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "actors",
+                "query-jobs"
+              ]
+            },
             "description": "Start simulated long‑running actor query"
           }
         },
@@ -445,7 +999,18 @@
           "name": "GET /jobs/{id}",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/jobs/{id}",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}"
+              ]
+            },
             "description": "Poll job status"
           }
         },
@@ -453,7 +1018,18 @@
           "name": "DELETE /jobs/{id}",
           "request": {
             "method": "DELETE",
-            "url": "{{baseUrl}}/jobs/{id}",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}"
+              ]
+            },
             "description": "Delete job"
           }
         },
@@ -461,17 +1037,23 @@
           "name": "GET /jobs/{id}/download",
           "request": {
             "method": "GET",
-            "url": "{{baseUrl}}/jobs/{id}/download",
+            "url": {
+              "raw": "http://localhost:3000/jobs/{id}/download",
+              "protocol": "http",
+              "host": [
+                "localhost"
+              ],
+              "port": "3000",
+              "path": [
+                "jobs",
+                "{id}",
+                "download"
+              ]
+            },
             "description": "Download job results (JSON)"
           }
         }
       ]
-    }
-  ],
-  "variable": [
-    {
-      "key": "baseUrl",
-      "value": "http://localhost:3000"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- generate admin interface for all API operations using OpenAPI spec
- support path/query parameters and optional JSON bodies per endpoint
- prefix all logs with the package version and bump to v1.0.9

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c590bcb7888321ba2a044e5ee89de2