### PR TITLE
chore: bump version to 1.0.9 and prefix logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.9] - 2025-09-13
+### Changed
+- Bumped package, Postman collection, and spec versions to 1.0.9.
+- Log lines now include the version prefix.
+
 ## [1.0.8] - 2025-09-04
 ### Changed
 - Bumped package, Docker Compose, Postman collection, and spec versions to 1.0.8.

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/server.js
+++ b/server.js
@@ -28,6 +28,12 @@ const { randomUUID } = require('crypto');
 require('dotenv').config();
 const pkg = require('./package.json');
 
+// Prepend version number to all log lines
+const originalLog = console.log;
+console.log = (...args) => originalLog(`[${pkg.version}]`, ...args);
+const originalError = console.error;
+console.error = (...args) => originalError(`[${pkg.version}]`, ...args);
+
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3000;
 const DB_HOST = process.env.DB_HOST || 'localhost';
 const DB_PORT = process.env.DB_PORT ? Number(process.env.DB_PORT) : 3306;
@@ -61,7 +67,11 @@ let pool;
 
 const app = express();
 app.use(express.json());
-app.use(morgan('dev'));
+app.use(morgan('dev', {
+  stream: {
+    write: msg => console.log(msg.trim())
+  }
+}));
 // simple admin web UI
 app.use('/admin', express.static(path.join(__dirname, 'public')));
 

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.0.8",
+    "version": "1.0.9",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [


### PR DESCRIPTION
## Summary
- bump package, spec and collection versions to 1.0.9
- prefix all console and HTTP request logs with the current version
- document versioned logging in CHANGELOG

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c59ba7849483219c7e85755110bc0a