### PR TITLE
Add entrypoint script to avoid exec format error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,9 @@ COPY package.json .
 RUN npm install
 
 COPY . .
+RUN chmod +x docker-entrypoint.sh
+
 EXPOSE 3000
 
+ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node","server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+set -e
+exec "$@"


### PR DESCRIPTION
## Summary
- add custom docker entrypoint script with proper shebang
- update Dockerfile to use new script and ensure executable

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5a44b81588321ae5b36c1b9129992