### PR TITLE
Build multi-arch Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ npm start
 curl -s http://localhost:3000/health | jq .
 ```
 
+### Docker multi-arch build
+```bash
+npm run docker:build
+```
+Builds and pushes images for x86_64, arm64, and armv7 using `docker buildx`.
+
 ### OpenAPI & Docs
 - JSON spec: `GET /openapi.json` (also `/spec` and `/.well-known/openapi.json`)
 - Swagger UI (optional): `npm i swagger-ui-express` then open `http://localhost:3000/docs`

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "test": "node --test",
-    "docker:build": "docker build -t ravelox/tvdb:latest -t ravelox/tvdb:${npm_package_version} ."
+    "docker:build": "./scripts/docker-buildx.sh"
   },
   "dependencies": {
     "dotenv": "^16.4.5",

--- a/scripts/docker-buildx.sh
+++ b/scripts/docker-buildx.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+docker buildx build --platform linux/arm/v7,linux/arm64,linux/amd64 \
+  -t ravelox/tvdb:latest \
+  -t ravelox/tvdb:${npm_package_version} \
+  --push .
+


### PR DESCRIPTION
## Summary
- add docker-buildx script to build and push images for amd64, arm64, and armv7
- expose script via npm `docker:build` and document multi-arch build instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5bd3c771483219ed9da81f234d372