### PR TITLE
Handle buildx without platform support

### DIFF
--- a/scripts/docker-buildx.sh
+++ b/scripts/docker-buildx.sh
@@ -1,8 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-docker buildx build --platform linux/arm/v7,linux/arm64,linux/amd64 \
-  -t ravelox/tvdb:latest \
-  -t ravelox/tvdb:${npm_package_version} \
-  --push .
+# Some Docker installations do not support the --platform flag.  If the
+# flag is unavailable we fall back to building for the host platform only.
+platforms="linux/arm/v7,linux/arm64,linux/amd64"
+
+if docker buildx build --help 2>&1 | grep -q -- '--platform'; then
+  docker buildx build --platform "$platforms" \
+    -t ravelox/tvdb:latest \
+    -t ravelox/tvdb:${npm_package_version} \
+    --push .
+else
+  docker buildx build \
+    -t ravelox/tvdb:latest \
+    -t ravelox/tvdb:${npm_package_version} \
+    --push .
+fi
 


### PR DESCRIPTION
## Summary
- avoid using `--platform` when the Docker buildx install doesn't support it

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5e649405c8321a2ffa2cd2348a37b