### PR TITLE
fix: buildx tag flags

### DIFF
--- a/scripts/docker-buildx.sh
+++ b/scripts/docker-buildx.sh
@@ -7,13 +7,13 @@ platforms="linux/arm/v7,linux/arm64,linux/amd64"
 
 if docker buildx build --help 2>&1 | grep -q -- '--platform'; then
   docker buildx build --platform "$platforms" \
-    -t ravelox/tvdb:latest \
-    -t ravelox/tvdb:${npm_package_version} \
+    --tag ravelox/tvdb:latest \
+    --tag ravelox/tvdb:${npm_package_version} \
     --push .
 else
   docker buildx build \
-    -t ravelox/tvdb:latest \
-    -t ravelox/tvdb:${npm_package_version} \
+    --tag ravelox/tvdb:latest \
+    --tag ravelox/tvdb:${npm_package_version} \
     --push .
 fi
 


### PR DESCRIPTION
## Summary
- use long --tag option in docker buildx script for compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5e71743e083219e5cc4c04a080846