### PR TITLE
Use -t flag for docker buildx tags

### DIFF
--- a/scripts/docker-buildx.sh
+++ b/scripts/docker-buildx.sh
@@ -7,13 +7,13 @@ platforms="linux/arm/v7,linux/arm64,linux/amd64"
 
 if docker buildx build --help 2>&1 | grep -q -- '--platform'; then
   docker buildx build --platform "$platforms" \
-    --tag ravelox/tvdb:latest \
-    --tag ravelox/tvdb:${npm_package_version} \
+    -t ravelox/tvdb:latest \
+    -t ravelox/tvdb:${npm_package_version} \
     --push .
 else
   docker buildx build \
-    --tag ravelox/tvdb:latest \
-    --tag ravelox/tvdb:${npm_package_version} \
+    -t ravelox/tvdb:latest \
+    -t ravelox/tvdb:${npm_package_version} \
     --push .
 fi
 


### PR DESCRIPTION
## Summary
- fix `docker-buildx.sh` to use `-t` instead of `--tag` for wider Docker buildx compatibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5e7e5176c8321a6fedf28070e39db