### PR TITLE
Fix multi-arch Docker build with Node 16 slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM node:slim
+ARG NODE_VERSION=16-slim
+FROM node:${NODE_VERSION}
 
 WORKDIR /app
 

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-platforms="linux/arm/v7,linux/arm64,linux/amd64"
+platforms="linux/arm/v7,linux/amd64,linux/arm64"
 builder="tvdb-multiarch"
+node_version="16-slim"
 
 # Ensure a docker-container builder is available
 if ! docker buildx inspect "$builder" >/dev/null 2>&1; then
@@ -14,6 +15,7 @@ fi
 docker buildx inspect --bootstrap
 
 docker buildx build --platform "$platforms" \
+  --build-arg NODE_VERSION="$node_version" \
   -t ravelox/tvdb:latest \
   -t ravelox/tvdb:${npm_package_version} \
   --push .


### PR DESCRIPTION
## Summary
- Build Docker images for armv7, amd64 and arm64 using Node 16 slim base image
- Allow Dockerfile to accept a `NODE_VERSION` build arg for compatibility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5ebeec0688321ba87e75c344867cd