### PR TITLE
Add Helm chart for tvdb

### DIFF
--- a/charts/tvdb/Chart.yaml
+++ b/charts/tvdb/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: tvdb
+description: A Helm chart for the tvdb application.
+type: application
+version: 0.1.0
+appVersion: "1.0.9"

--- a/charts/tvdb/templates/app-deployment.yaml
+++ b/charts/tvdb/templates/app-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tvdb-app-deployment
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: tvdb
+spec:
+  replicas: {{ .Values.app.replicas }}
+  selector:
+    matchLabels:
+      app: tvdb
+  template:
+    metadata:
+      labels:
+        app: tvdb
+    spec:
+      initContainers:
+      - name: wait-for-storage
+        image: busybox:1.28
+        command: ['sh', '-c', 'until nc -zv tvdb-database 3306; do echo waiting for database; sleep 2; done']
+      containers:
+      - name: tvdb-app
+        image: {{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+        env:
+        - name: PORT
+          value: "3000"
+        - name: DB_HOST
+          value: tvdb-database
+        - name: DB_PORT
+          value: "3306"
+        - name: DB_USER
+          value: root
+        - name: DB_PASSWORD
+          value: {{ .Values.storage.password | quote }}
+        - name: DB_NAME
+          value: tvdb

--- a/charts/tvdb/templates/app-service.yaml
+++ b/charts/tvdb/templates/app-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tvdb-app
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: tvdb
+spec:
+  type: ClusterIP
+  ports:
+  - name: tvdb-app-port
+    protocol: TCP
+    port: 3000
+    targetPort: 3000
+  selector:
+    app: tvdb

--- a/charts/tvdb/templates/namespace.yaml
+++ b/charts/tvdb/templates/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace }}

--- a/charts/tvdb/templates/storage-deployment.yaml
+++ b/charts/tvdb/templates/storage-deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: tvdb-storage-deployment
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: tvdb
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: tvdb
+  template:
+    metadata:
+      labels:
+        app: tvdb
+    spec:
+      containers:
+      - image: {{ .Values.storage.image.repository }}:{{ .Values.storage.image.tag }}
+        imagePullPolicy: IfNotPresent
+        name: mysql
+        env:
+        - name: MYSQL_ROOT_PASSWORD
+          value: {{ .Values.storage.password | quote }}
+        ports:
+        - containerPort: 3306
+        readinessProbe:
+          exec:
+            command: ["mysqladmin", "ping", "-h", "127.0.0.1"]
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        volumeMounts:
+        - name: tvdb-storage-volume
+          mountPath: /var/lib/mysql
+      volumes:
+      - name: tvdb-storage-volume
+        persistentVolumeClaim:
+          claimName: tvdb-storage-pvc

--- a/charts/tvdb/templates/storage-pv.yaml
+++ b/charts/tvdb/templates/storage-pv.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: tvdb-storage-pv
+  namespace: {{ .Values.namespace }}
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: {{ .Values.storage.volume.storage }}
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: {{ .Values.storage.volume.hostPath | quote }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: tvdb-storage-pvc
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: tvdb
+spec:
+  accessModes:
+  - ReadWriteOnce
+  storageClassName: manual
+  resources:
+    requests:
+      storage: {{ .Values.storage.volume.storage }}

--- a/charts/tvdb/templates/storage-service.yaml
+++ b/charts/tvdb/templates/storage-service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: tvdb-database
+  namespace: {{ .Values.namespace }}
+  labels:
+    app: tvdb
+spec:
+  type: ClusterIP
+  ports:
+  - name: mysql-port
+    protocol: TCP
+    port: 3306
+    targetPort: 3306
+  selector:
+    app: tvdb

--- a/charts/tvdb/values.yaml
+++ b/charts/tvdb/values.yaml
@@ -1,0 +1,14 @@
+namespace: tvdb
+app:
+  image:
+    repository: ravelox/tvdb
+    tag: latest
+  replicas: 1
+storage:
+  image:
+    repository: mysql
+    tag: "8.0"
+  password: admin
+  volume:
+    hostPath: /vagrant/data/mysql
+    storage: 500Mi


### PR DESCRIPTION
## Summary
- add Helm chart converting existing k8s manifests
- parameterize app and MySQL settings via values.yaml

## Testing
- `npm test`
- `helm lint charts/tvdb` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f11fbc188321baed778ed9a890e2