### PR TITLE
docs: add helm deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,19 +31,20 @@ helm template tvdb charts/tvdb
 Renders the Kubernetes manifests from `charts/tvdb` without installing the chart. Use `-f my-values.yaml` to supply custom values.
 
 ### Deploy the Helm chart
-```bash
-helm install tvdb charts/tvdb
-```
-Installs the manifests into your cluster using the current Kubernetes context. Use `-f my-values.yaml` or `--set key=value` to customize the deployment. For idempotent upgrades, run `helm upgrade --install`.
-
-If installation fails because a `tvdb-storage-pv` volume already exists without Helm labels, either delete it or add the required metadata so Helm can take ownership:
+If a `tvdb-storage-pv` volume already exists, label and annotate it so Helm can take ownership:
 
 ```bash
 kubectl label pv tvdb-storage-pv app.kubernetes.io/managed-by=Helm
 kubectl annotate pv tvdb-storage-pv meta.helm.sh/release-name=tvdb meta.helm.sh/release-namespace=default
 ```
 
-Replace `default` if you are installing into a different namespace.
+Replace `default` if you are installing into a different namespace. Then deploy (or upgrade) the chart:
+
+```bash
+helm upgrade --install tvdb charts/tvdb
+```
+
+Installs the manifests into your cluster using the current Kubernetes context. Use `-f my-values.yaml` or `--set key=value` to customize the deployment.
 
 ### OpenAPI & Docs
 - JSON spec: `GET /openapi.json` (also `/spec` and `/.well-known/openapi.json`)


### PR DESCRIPTION
## Summary
- document how to handle existing `tvdb-storage-pv` when installing Helm chart

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5f6e3d2748321925294272efd4bc6