### PR TITLE
docs: add helm deployment guidance and pv labels

### DIFF
--- a/charts/tvdb/templates/storage-pv.yaml
+++ b/charts/tvdb/templates/storage-pv.yaml
@@ -2,9 +2,12 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: tvdb-storage-pv
-  namespace: {{ .Values.namespace }}
   labels:
     type: local
+    app.kubernetes.io/managed-by: Helm
+  annotations:
+    meta.helm.sh/release-name: {{ .Release.Name }}
+    meta.helm.sh/release-namespace: {{ .Release.Namespace }}
 spec:
   storageClassName: manual
   capacity:


### PR DESCRIPTION
## Summary
- add detailed Helm deployment instructions and notes on labeling pre-existing PVs
- embed Helm ownership labels/annotations in PersistentVolume template

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5ff744d788321b5dab9a17369e2f2