### PR TITLE
Add hostPath type to Helm PersistentVolume template

### DIFF
--- a/charts/tvdb/templates/storage-pv.yaml
+++ b/charts/tvdb/templates/storage-pv.yaml
@@ -17,6 +17,7 @@ spec:
   persistentVolumeReclaimPolicy: Retain
   hostPath:
     path: {{ .Values.storage.volume.hostPath | quote }}
+    type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/k8s/tvdb-storage-pv.yaml
+++ b/k8s/tvdb-storage-pv.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: tvdb-storage-pv
-  namespace: tvdb
 spec:
   storageClassName: openebs-hostpath
   volumeMode: Filesystem
@@ -11,3 +10,6 @@ spec:
   accessModes:
   - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: /var/lib/tvdb
+    type: DirectoryOrCreate


### PR DESCRIPTION
## Summary
- add the hostPath type to the Helm chart PersistentVolume so the directory is created automatically, matching the standalone manifest fix

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68c843a55b708321ad31543ab81eb3a4