### PR TITLE
Align indentation in k8s persistent volume manifest

### DIFF
--- a/charts/tvdb/templates/storage-pv.yaml
+++ b/charts/tvdb/templates/storage-pv.yaml
@@ -13,7 +13,7 @@ spec:
   capacity:
     storage: {{ .Values.storage.volume.storage }}
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
   hostPath:
     path: {{ .Values.storage.volume.hostPath | quote }}
@@ -28,7 +28,7 @@ metadata:
     app: tvdb
 spec:
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   storageClassName: manual
   resources:
     requests:

--- a/k8s/tvdb-storage-pv.yaml
+++ b/k8s/tvdb-storage-pv.yaml
@@ -8,8 +8,8 @@ spec:
   capacity:
     storage: 500Mi
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
   persistentVolumeReclaimPolicy: Retain
-#  hostPath:
-#    path: /var/lib/tvdb
-#    type: DirectoryOrCreate
+  # hostPath:
+  #   path: /var/lib/tvdb
+  #   type: DirectoryOrCreate


### PR DESCRIPTION
## Summary
- correct the indentation of the ReadWriteOnce access mode in the standalone PersistentVolume manifest
- align the commented hostPath block with the rest of the spec for readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c8614b687083218f33811ccf6f70c7