### PR TITLE
Bump version to 1.0.11 and add uninstall docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.0.11] - 2025-09-20
+### Added
+- Documented API uninstall/cleanup steps in the README.
+### Changed
+- Bumped package, OpenAPI spec, Postman collection, Docker, Helm chart, and Kubernetes deployment versions to 1.0.11.
+
 ## [1.0.10] - 2025-09-16
 ### Changed
 - Bumped package, OpenAPI spec, Postman collection, Docker, Helm chart, and Kubernetes deployment versions to 1.0.10.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ The API exposes a few optional environment variables for authentication and back
 
 See `.env.example` for a compose-ready set of defaults.
 
+### Uninstall / Cleanup
+
+When you're done experimenting you can tear everything down:
+
+- **Local Node.js install:** stop `npm start` (Ctrl+C), delete the install artifacts with `rm -rf node_modules package-lock.json`, and drop the schema the API created by connecting to MySQL and running `DROP DATABASE <your DB_NAME>;` (the default is `tvdb`).
+- **Docker Compose:** run `docker compose down -v` to stop the stack and remove the bind-mounted database volume.
+- **Helm release:** run `helm uninstall tvdb -n tvdb` (or your namespace) and, if you created persistent volumes, clean them up with `kubectl delete pvc -n <namespace> -l app=tvdb`.
+
 ### Docker multi-arch build
 ```bash
 npm run docker:build

--- a/charts/tvdb/Chart.yaml
+++ b/charts/tvdb/Chart.yaml
@@ -3,4 +3,4 @@ name: tvdb
 description: A Helm chart for the tvdb application.
 type: application
 version: 0.1.0
-appVersion: "1.0.10"
+appVersion: "1.0.11"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
     ports:
       - "6888:80"
   tvdb:
-    image: ${TVDB_IMAGE:-ravelox/tvdb:1.0.10}
+    image: ${TVDB_IMAGE:-ravelox/tvdb:1.0.11}
     build:
       context: .
       args:

--- a/k8s/tvdb-app-deployment.yaml
+++ b/k8s/tvdb-app-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         command: ['sh', '-c', 'until nc -zv tvdb-database 3306; do echo waiting for database; sleep 2; done']
       containers:
       - name: tvdb-app
-        image: ravelox/tvdb:1.0.10
+        image: ravelox/tvdb:1.0.11
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.0.10",
+    "version": "1.0.11",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [


### PR DESCRIPTION
## Summary
- bump the application version references to 1.0.11 across the distribution artifacts
- document uninstall and cleanup guidance in the README
- capture the changes in the changelog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68cb1e39399c83219fc21f4a4553dc2a