### PR TITLE
Adopt semver with automated build numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 package-lock.json
 *code-workspace
+.docker-build-number

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.0] - 2025-09-22
+### Changed
+- Adopted a semantic version baseline of 1.1.0 across the package, specs, and deployment assets.
+- Added automated build numbering to the Docker helper and image metadata so each rebuild gets a unique tag.
+
 ## [1.0.11] - 2025-09-20
 ### Added
 - Documented API uninstall/cleanup steps in the README.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
 ARG NODE_VERSION=20.12.2-slim
 FROM node:${NODE_VERSION}
 
+ARG APP_VERSION=0.0.0
+ARG BUILD_NUMBER=0
+LABEL org.opencontainers.image.version="${APP_VERSION}"
+LABEL org.opencontainers.image.revision="${BUILD_NUMBER}"
+ENV APP_VERSION=${APP_VERSION}
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+
 WORKDIR /app
 
 COPY package.json .

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ npm run docker:build -- --push
 ```
 By default the helper script builds an x86_64 image locally (loaded into your Docker daemon). Pass `--push` to publish the multi-architecture image set.
 
+Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.1.0`) plus a unique build suffix such as `1.1.0-build.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
+
 ### Helm deployment
 Render the manifests without installing:
 ```bash

--- a/charts/tvdb/Chart.yaml
+++ b/charts/tvdb/Chart.yaml
@@ -3,4 +3,4 @@ name: tvdb
 description: A Helm chart for the tvdb application.
 type: application
 version: 0.1.0
-appVersion: "1.0.11"
+appVersion: "1.1.0"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,11 +27,13 @@ services:
     ports:
       - "6888:80"
   tvdb:
-    image: ${TVDB_IMAGE:-ravelox/tvdb:1.0.11}
+    image: ${TVDB_IMAGE:-ravelox/tvdb:1.1.0}
     build:
       context: .
       args:
         NODE_VERSION: ${NODE_VERSION:-20.12.2-slim}
+        APP_VERSION: ${APP_VERSION:-1.1.0}
+        BUILD_NUMBER: ${BUILD_NUMBER:-0}
     restart: always
     depends_on:
       db:

--- a/k8s/tvdb-app-deployment.yaml
+++ b/k8s/tvdb-app-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         command: ['sh', '-c', 'until nc -zv tvdb-database 3306; do echo waiting for database; sleep 2; done']
       containers:
       - name: tvdb-app
-        image: ravelox/tvdb:1.0.11
+        image: ravelox/tvdb:1.1.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.0.11",
+    "version": "1.1.0",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.0.11",
+  "version": "1.1.0",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -5,6 +5,8 @@ platforms="linux/arm/v7,linux/arm64,linux/amd64"
 builder="tvdb-multiarch"
 node_version="20.12.2-slim"
 push_image=false
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "${script_dir}/.." && pwd)"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -46,12 +48,44 @@ fi
 
 docker buildx inspect --bootstrap
 
+cd "$repo_dir"
+
+if [[ -n "${npm_package_version:-}" ]]; then
+  app_version="$npm_package_version"
+else
+  app_version="$(node -p "require('${repo_dir}/package.json').version")"
+fi
+
+build_number_file="${repo_dir}/.docker-build-number"
+if [[ -f "$build_number_file" ]]; then
+  if ! read -r previous_build_number <"$build_number_file"; then
+    previous_build_number=0
+  fi
+else
+  previous_build_number=0
+fi
+
+if [[ "$previous_build_number" =~ ^[0-9]+$ ]]; then
+  next_build_number=$((previous_build_number + 1))
+else
+  next_build_number=1
+fi
+
+printf '%s\n' "$next_build_number" >"$build_number_file"
+
+full_version="${app_version}-build.${next_build_number}"
+
+echo "Building ravelox/tvdb:${full_version} (base ${app_version}, build #${next_build_number})"
+
 build_args=(
   docker buildx build
   --platform "$platforms"
   --build-arg NODE_VERSION="$node_version"
+  --build-arg APP_VERSION="$app_version"
+  --build-arg BUILD_NUMBER="$next_build_number"
   -t ravelox/tvdb:latest
-  -t ravelox/tvdb:${npm_package_version}
+  -t ravelox/tvdb:"$app_version"
+  -t ravelox/tvdb:"$full_version"
 )
 
 if $push_image; then

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.0.11",
+    "version": "1.1.0",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [


### PR DESCRIPTION
## Summary
- bump the application version to 1.1.0 across the package metadata, API specs, and deployment manifests
- teach the Docker build helper to mint semantic build tags, persist an incrementing build counter, and surface version/build args in the image
- document the new build-number flow and propagate the build args through docker-compose and the Helm chart

## Testing
- npm test
- node scripts/generate-postman.js

------
https://chatgpt.com/codex/tasks/task_e_68cb2d3bcff48321a7c9bb397bd4ee41