### PR TITLE
Add deployment version endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -194,6 +194,19 @@
         ]
       }
     },
+    "/deployment-version": {
+      "get": {
+        "tags": [
+          "health"
+        ],
+        "summary": "Get app deployment version",
+        "responses": {
+          "200": {
+            "description": "Deployment version"
+          }
+        }
+      }
+    },
     "/init": {
       "post": {
         "tags": [

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -18,6 +18,14 @@
           }
         },
         {
+          "name": "GET /deployment-version",
+          "request": {
+            "method": "GET",
+            "url": "{{baseUrl}}/deployment-version",
+            "description": "Get app deployment version"
+          }
+        },
+        {
           "name": "POST /init",
           "request": {
             "method": "POST",


### PR DESCRIPTION
## Summary
- add a `/deployment-version` endpoint that exposes app, build, and package version metadata
- document the new endpoint in the bundled OpenAPI spec and regenerate the Postman collection
- extend the API test suite to cover the deployment version response
- ensure the `/deployment-version` documentation omits unrelated optional filter parameters

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb31cdebd8832192755d132e90f37f