### PR TITLE
Remove 'build' label from build numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run docker:build -- --push
 ```
 By default the helper script builds an x86_64 image locally (loaded into your Docker daemon). Pass `--push` to publish the multi-architecture image set.
 
-Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.1.0`) plus a unique build suffix such as `1.1.0-build.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
+Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.1.0`) plus a numeric suffix such as `1.1.0.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
 
 ### Helm deployment
 Render the manifests without installing:

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -73,7 +73,7 @@ fi
 
 printf '%s\n' "$next_build_number" >"$build_number_file"
 
-full_version="${app_version}-build.${next_build_number}"
+full_version="${app_version}.${next_build_number}"
 
 echo "Building ravelox/tvdb:${full_version} (base ${app_version}, build #${next_build_number})"
 

--- a/server.js
+++ b/server.js
@@ -41,7 +41,7 @@ const DB_NAME = process.env.DB_NAME || 'tvdb';
 const APP_VERSION = process.env.APP_VERSION || pkg.version;
 const BUILD_NUMBER = process.env.BUILD_NUMBER ?? null;
 // Prepend version/build tag to all log lines
-const logVersionTag = BUILD_NUMBER != null ? `${APP_VERSION}-build.${BUILD_NUMBER}` : APP_VERSION;
+const logVersionTag = BUILD_NUMBER != null ? `${APP_VERSION}.${BUILD_NUMBER}` : APP_VERSION;
 console.log = (...args) => originalLog(`[${logVersionTag}]`, ...args);
 console.error = (...args) => originalError(`[${logVersionTag}]`, ...args);
 const ENABLE_ADMIN_UI = process.env.ENABLE_ADMIN_UI != null


### PR DESCRIPTION
## Summary
- change the deployment log prefix to drop the literal "build" label from version tags
- retag docker builds without the "-build" infix and document the new format

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb37b0b6ec83219ae08f014e0b364c