### PR TITLE
Improve seed scripts retry handling

### DIFF
--- a/scripts/seed_common.sh
+++ b/scripts/seed_common.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+
+# Shared helpers for the TVDB seed scripts. The functions here wrap curl with
+# retry logic so the scripts can tolerate temporary database outages or startup
+# races while the API is still wiring up its MySQL connection.
+
+: "${API:=http://localhost:3000}"
+
+# How many times to retry a request that fails due to network errors, 5xx
+# responses, or known database connectivity messages.
+SEED_MAX_RETRIES=${SEED_MAX_RETRIES:-10}
+# Base delay (in seconds) between retries. The delay increases linearly with
+# each attempt to give the database a chance to recover.
+SEED_RETRY_DELAY=${SEED_RETRY_DELAY:-2}
+
+# Captures the HTTP status from the most recent call to seed_api_request and
+# friends. Scripts can inspect this (e.g., to treat a missing /init endpoint as
+# non-fatal).
+SEED_HTTP_STATUS=0
+
+seed__normalize_url() {
+  local raw="$1"
+  if [[ "$raw" =~ ^https?:// ]]; then
+    printf '%s' "$raw"
+  elif [[ "$raw" == /* ]]; then
+    printf '%s%s' "$API" "$raw"
+  else
+    printf '%s/%s' "$API" "$raw"
+  fi
+}
+
+seed__should_retry() {
+  local exit_code="$1"
+  local status="$2"
+  local body="$3"
+
+  if (( exit_code != 0 )); then
+    return 0
+  fi
+
+  if [[ "$status" =~ ^5 ]]; then
+    return 0
+  fi
+
+  if printf '%s' "$body" | grep -qiE 'connect (?:econn|etimedout)|connection refused|database .*unavailable|pool is closed'; then
+    return 0
+  fi
+
+  return 1
+}
+
+seed_api_request() {
+  if (( $# < 2 )); then
+    echo "seed_api_request requires a method and URL" >&2
+    return 1
+  fi
+
+  local method="$1"
+  shift
+  local url
+  url=$(seed__normalize_url "$1")
+  shift
+
+  local attempt=1
+  local status="000"
+  local exit_code=0
+  local body=""
+
+  while (( attempt <= SEED_MAX_RETRIES )); do
+    local tmp
+    tmp=$(mktemp)
+
+    set +e
+    status=$(command curl --silent --show-error --request "$method" "$url" "$@" --output "$tmp" --write-out '%{http_code}')
+    exit_code=$?
+    set -e
+
+    if [[ -s "$tmp" ]]; then
+      body=$(cat "$tmp")
+    else
+      body=""
+    fi
+    rm -f "$tmp"
+
+    if (( exit_code == 0 )) && [[ "$status" =~ ^2[0-9][0-9]$ ]]; then
+      SEED_HTTP_STATUS=$status
+      printf '%s' "$body"
+      return 0
+    fi
+
+    if (( attempt < SEED_MAX_RETRIES )) && seed__should_retry "$exit_code" "$status" "$body"; then
+      local sleep_for=$(( SEED_RETRY_DELAY * attempt ))
+      local descriptor
+      if (( exit_code != 0 )); then
+        descriptor="curl exit $exit_code"
+      else
+        descriptor="HTTP $status"
+      fi
+      if [[ -n "$body" ]]; then
+        descriptor+=" — $(printf '%s' "$body" | head -n1)"
+      fi
+      echo "Retrying $method $url in ${sleep_for}s (${descriptor})" >&2
+      sleep "$sleep_for"
+      attempt=$(( attempt + 1 ))
+      continue
+    fi
+
+    SEED_HTTP_STATUS=$status
+    if (( exit_code != 0 )); then
+      echo "Request to $url failed with curl exit $exit_code" >&2
+    else
+      echo "Request to $url failed with status $status" >&2
+    fi
+    if [[ -n "$body" ]]; then
+      echo "$body" >&2
+    fi
+    return 1
+  done
+
+  SEED_HTTP_STATUS=$status
+  return 1
+}
+
+seed_api_get() { seed_api_request GET "$@"; }
+seed_api_post() { seed_api_request POST "$@"; }
+seed_api_put() { seed_api_request PUT "$@"; }
+seed_api_delete() { seed_api_request DELETE "$@"; }
+
+seed_init_database() {
+  local err_file
+  err_file=$(mktemp)
+  if seed_api_post "$API/init" >/dev/null 2>"$err_file"; then
+    echo "[init] Database ensured"
+    rm -f "$err_file"
+    return 0
+  fi
+
+  local status="${SEED_HTTP_STATUS:-}"
+  if [[ "$status" == "404" ]]; then
+    echo "[init] Skipped or not supported"
+    rm -f "$err_file"
+    return 0
+  fi
+
+  if [[ -s "$err_file" ]]; then
+    cat "$err_file" >&2
+  fi
+  rm -f "$err_file"
+  echo "[init] Unable to initialize database (status=${status:-unknown})"
+  return 0
+}
+

--- a/seed_space_1999.sh
+++ b/seed_space_1999.sh
@@ -3,19 +3,23 @@ set -euo pipefail
 
 API="${API:-http://localhost:3000}"
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/seed_common.sh
+source "$SCRIPT_DIR/scripts/seed_common.sh"
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required"; exit 1
 fi
 
 json() { jq -c -n "$1"; }
 
-curl -s -o /dev/null -w "%{http_code}\n" -X POST "$API/init" | grep -qE '^(200|201|204)$' && echo "[init] Database ensured" || echo "[init] Skipped or not supported"
+seed_init_database
 
-SHOW_ID=$(curl -s "$API/shows" | jq -r '
+SHOW_ID=$(seed_api_get "$API/shows" | jq -r '
   map(select(.title=="Space: 1999" and .year==1975)) | (.[0].id // empty)
 ')
 if [ -z "${SHOW_ID:-}" ]; then
-  SHOW_ID=$(curl -s -X POST "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"Space: 1999", description:"British-Italian science fiction series", year:1975}')" | jq -r '.id')
+  SHOW_ID=$(seed_api_post "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"Space: 1999", description:"British-Italian science fiction series", year:1975}')" | jq -r '.id')
   echo "Created show: Space: 1999 (id=$SHOW_ID)"
 else
   echo "Using existing show: Space: 1999 (id=$SHOW_ID)"
@@ -26,14 +30,14 @@ read -r -d '' SEASONS <<'EOF_SEASONS' || true
 2|1976
 EOF_SEASONS
 
-existing_seasons=$(curl -s "$API/shows/$SHOW_ID/seasons")
+existing_seasons=$(seed_api_get "$API/shows/$SHOW_ID/seasons")
 printf '%s\n' "$SEASONS" | while IFS='|' read -r s y; do
   [ -z "$s" ] && continue
   if echo "$existing_seasons" | jq -e --argjson s "$s" 'map(.season_number)|index($s)' >/dev/null; then
     echo "Season $s already exists"
   else
     echo "Creating Season $s (year $y)"
-    curl -s -X POST "$API/shows/$SHOW_ID/seasons" \
+    seed_api_post "$API/shows/$SHOW_ID/seasons" \
       -H 'Content-Type: application/json' \
       -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
   fi
@@ -55,19 +59,19 @@ Jeffrey Kissoon
 Yasuko Nagazumi
 EOF_ACTORS
 
-actors_json=$(curl -s "$API/actors")
+actors_json=$(seed_api_get "$API/actors")
 printf '%s\n' "$ACTORS" | while IFS= read -r name; do
   [ -z "$name" ] && continue
   if echo "$actors_json" | jq -e --arg n "$name" 'map(.name)|index($n)' >/dev/null; then
     echo "Actor exists: $name"
   else
     echo "Creating actor: $name"
-    curl -s -X POST "$API/actors" \
+    seed_api_post "$API/actors" \
       -H 'Content-Type: application/json' \
       -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
   fi
 done
-actors_json=$(curl -s "$API/actors")
+actors_json=$(seed_api_get "$API/actors")
 
 read -r -d '' CHAR_TO_ACTOR <<'EOF_CHARS' || true
 Commander John Koenig|Martin Landau
@@ -85,14 +89,14 @@ Dr. Ben Vincent|Jeffrey Kissoon
 Yasko|Yasuko Nagazumi
 EOF_CHARS
 
-chars_json=$(curl -s "$API/shows/$SHOW_ID/characters")
+chars_json=$(seed_api_get "$API/shows/$SHOW_ID/characters")
 printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
   [ -z "$char" ] && continue
   if echo "$chars_json" | jq -e --arg n "$char" 'map(.name)|index($n)' >/dev/null; then
     echo "Character exists: $char"
   else
     echo "Creating character: $char (actor: $actor)"
-    curl -s -X POST "$API/shows/$SHOW_ID/characters" \
+    seed_api_post "$API/shows/$SHOW_ID/characters" \
       -H 'Content-Type: application/json' \
       -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
   fi
@@ -155,7 +159,7 @@ read -r -d '' EPISODES <<'EOF_EPISODES' || true
 2|1977-02-12|The Dorcons|A dying empire hunts Maya for the secret of immortality.|S2_CHARS
 EOF_EPISODES
 
-existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
+existing_eps=$(seed_api_get "$API/shows/$SHOW_ID/episodes")
 printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description char_key; do
   [ -z "$season" ] && continue
   if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
@@ -163,9 +167,9 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   else
     echo "Creating episode (S${season}): $title"
     jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' |
-      curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+      seed_api_post "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
   fi
-  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
+  EP_ID=$(seed_api_get "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
   [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
 
   case "$char_key" in
@@ -180,7 +184,7 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   echo "$char_list" | tr ';' '\n' | while IFS='=' read -r char_name actor_name; do
     [ -z "$char_name" ] && continue
     echo "  Linking $char_name (actor: $actor_name)"
-    curl -s -X POST "$API/episodes/$EP_ID/characters" \
+    seed_api_post "$API/episodes/$EP_ID/characters" \
       -H 'Content-Type: application/json' \
       -d "$(jq -nc --arg n "$char_name" --arg a "$actor_name" '{character_name:$n, actor_name:$a}')" >/dev/null || true
   done

--- a/seed_stargate_universe.sh
+++ b/seed_stargate_universe.sh
@@ -3,19 +3,23 @@ set -euo pipefail
 
 API="${API:-http://localhost:3000}"
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/seed_common.sh
+source "$SCRIPT_DIR/scripts/seed_common.sh"
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required"; exit 1
 fi
 
 json() { jq -c -n "$1"; }
 
-curl -s -o /dev/null -w "%{http_code}\n" -X POST "$API/init" | grep -qE '^(200|201|204)$' && echo "[init] Database ensured" || echo "[init] Skipped or not supported"
+seed_init_database
 
-SHOW_ID=$(curl -s "$API/shows" | jq -r '
+SHOW_ID=$(seed_api_get "$API/shows" | jq -r '
   map(select(.title=="Stargate Universe" and .year==2009)) | (.[0].id // empty)
 ')
 if [ -z "${SHOW_ID:-}" ]; then
-  SHOW_ID=$(curl -s -X POST "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"Stargate Universe", description:"Canadian-American military science fiction series", year:2009}')" | jq -r '.id')
+  SHOW_ID=$(seed_api_post "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"Stargate Universe", description:"Canadian-American military science fiction series", year:2009}')" | jq -r '.id')
   echo "Created show: Stargate Universe (id=$SHOW_ID)"
 else
   echo "Using existing show: Stargate Universe (id=$SHOW_ID)"
@@ -26,14 +30,14 @@ read -r -d '' SEASONS <<'EOF2' || true
 2|2010
 EOF2
 
-existing_seasons=$(curl -s "$API/shows/$SHOW_ID/seasons")
+existing_seasons=$(seed_api_get "$API/shows/$SHOW_ID/seasons")
 printf '%s\n' "$SEASONS" | while IFS='|' read -r s y; do
   [ -z "$s" ] && continue
   if echo "$existing_seasons" | jq -e --argjson s "$s" 'map(.season_number)|index($s)' >/dev/null; then
     echo "Season $s already exists"
   else
     echo "Creating Season $s (year $y)"
-    curl -s -X POST "$API/shows/$SHOW_ID/seasons" -H 'Content-Type: application/json' -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
+    seed_api_post "$API/shows/$SHOW_ID/seasons" -H 'Content-Type: application/json' -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
   fi
 done
 
@@ -44,17 +48,17 @@ David Blue
 Elyse Levesque
 EOF2
 
-actors_json=$(curl -s "$API/actors")
+actors_json=$(seed_api_get "$API/actors")
 printf '%s\n' "$ACTORS" | while IFS= read -r name; do
   [ -z "$name" ] && continue
   if echo "$actors_json" | jq -e --arg n "$name" 'map(.name)|index($n)' >/dev/null; then
     echo "Actor exists: $name"
   else
     echo "Creating actor: $name"
-    curl -s -X POST "$API/actors" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
+    seed_api_post "$API/actors" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
   fi
 done
-actors_json=$(curl -s "$API/actors")
+actors_json=$(seed_api_get "$API/actors")
 
 read -r -d '' CHAR_TO_ACTOR <<'EOF2' || true
 Dr. Nicholas Rush|Robert Carlyle
@@ -63,14 +67,14 @@ Eli Wallace|David Blue
 Chloe Armstrong|Elyse Levesque
 EOF2
 
-chars_json=$(curl -s "$API/shows/$SHOW_ID/characters")
+chars_json=$(seed_api_get "$API/shows/$SHOW_ID/characters")
 printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
   [ -z "$char" ] && continue
   if echo "$chars_json" | jq -e --arg n "$char" 'map(.name)|index($n)' >/dev/null; then
     echo "Character exists: $char"
   else
     echo "Creating character: $char (actor: $actor)"
-    curl -s -X POST "$API/shows/$SHOW_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
+    seed_api_post "$API/shows/$SHOW_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
   fi
 done
 
@@ -88,20 +92,20 @@ read -r -d '' EPISODES <<'EOF2' || true
 2|2010-10-26|Cloverdale|Scott lives an alternate reality.
 EOF2
 
-existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
+existing_eps=$(seed_api_get "$API/shows/$SHOW_ID/episodes")
 printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
   [ -z "$season" ] && continue
   if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
     echo "Episode exists (S${season}): $title"
   else
     echo "Creating episode (S${season}): $title"
-    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | seed_api_post "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
   fi
-  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
+  EP_ID=$(seed_api_get "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
   [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
   for char in "Dr. Nicholas Rush" "Col. Everett Young" "Eli Wallace" "Chloe Armstrong"; do
     echo "  Linking $char"
-    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+    seed_api_post "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
   done
 done
 

--- a/seed_the_expanse.sh
+++ b/seed_the_expanse.sh
@@ -3,19 +3,23 @@ set -euo pipefail
 
 API="${API:-http://localhost:3000}"
 
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=scripts/seed_common.sh
+source "$SCRIPT_DIR/scripts/seed_common.sh"
+
 if ! command -v jq >/dev/null 2>&1; then
   echo "jq is required"; exit 1
 fi
 
 json() { jq -c -n "$1"; }
 
-curl -s -o /dev/null -w "%{http_code}\n" -X POST "$API/init" | grep -qE '^(200|201|204)$' && echo "[init] Database ensured" || echo "[init] Skipped or not supported"
+seed_init_database
 
-SHOW_ID=$(curl -s "$API/shows" | jq -r '
+SHOW_ID=$(seed_api_get "$API/shows" | jq -r '
   map(select(.title=="The Expanse" and .year==2015)) | (.[0].id // empty)
 ')
 if [ -z "${SHOW_ID:-}" ]; then
-  SHOW_ID=$(curl -s -X POST "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"The Expanse", description:"American science fiction series", year:2015}')" | jq -r '.id')
+  SHOW_ID=$(seed_api_post "$API/shows" -H 'Content-Type: application/json' -d "$(json '{title:"The Expanse", description:"American science fiction series", year:2015}')" | jq -r '.id')
   echo "Created show: The Expanse (id=$SHOW_ID)"
 else
   echo "Using existing show: The Expanse (id=$SHOW_ID)"
@@ -30,14 +34,14 @@ read -r -d '' SEASONS <<'EOF2' || true
 6|2021
 EOF2
 
-existing_seasons=$(curl -s "$API/shows/$SHOW_ID/seasons")
+existing_seasons=$(seed_api_get "$API/shows/$SHOW_ID/seasons")
 printf '%s\n' "$SEASONS" | while IFS='|' read -r s y; do
   [ -z "$s" ] && continue
   if echo "$existing_seasons" | jq -e --argjson s "$s" 'map(.season_number)|index($s)' >/dev/null; then
     echo "Season $s already exists"
   else
     echo "Creating Season $s (year $y)"
-    curl -s -X POST "$API/shows/$SHOW_ID/seasons" -H 'Content-Type: application/json' -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
+    seed_api_post "$API/shows/$SHOW_ID/seasons" -H 'Content-Type: application/json' -d "$(jq -nc --argjson s "$s" --argjson y "$y" '{season_number:$s, year:$y}')" >/dev/null
   fi
 done
 
@@ -48,17 +52,17 @@ Cas Anvar
 Wes Chatham
 EOF2
 
-actors_json=$(curl -s "$API/actors")
+actors_json=$(seed_api_get "$API/actors")
 printf '%s\n' "$ACTORS" | while IFS= read -r name; do
   [ -z "$name" ] && continue
   if echo "$actors_json" | jq -e --arg n "$name" 'map(.name)|index($n)' >/dev/null; then
     echo "Actor exists: $name"
   else
     echo "Creating actor: $name"
-    curl -s -X POST "$API/actors" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
+    seed_api_post "$API/actors" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$name" '{name:$n}')" >/dev/null
   fi
 done
-actors_json=$(curl -s "$API/actors")
+actors_json=$(seed_api_get "$API/actors")
 
 read -r -d '' CHAR_TO_ACTOR <<'EOF2' || true
 James Holden|Steven Strait
@@ -67,14 +71,14 @@ Alex Kamal|Cas Anvar
 Amos Burton|Wes Chatham
 EOF2
 
-chars_json=$(curl -s "$API/shows/$SHOW_ID/characters")
+chars_json=$(seed_api_get "$API/shows/$SHOW_ID/characters")
 printf '%s\n' "$CHAR_TO_ACTOR" | while IFS='|' read -r char actor; do
   [ -z "$char" ] && continue
   if echo "$chars_json" | jq -e --arg n "$char" 'map(.name)|index($n)' >/dev/null; then
     echo "Character exists: $char"
   else
     echo "Creating character: $char (actor: $actor)"
-    curl -s -X POST "$API/shows/$SHOW_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
+    seed_api_post "$API/shows/$SHOW_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" --arg a "$actor" '{name:$n, actor_name:$a}')" >/dev/null
   fi
 done
 
@@ -112,16 +116,16 @@ read -r -d '' EPISODES <<'EOF2' || true
 6|2022-01-07|Why We Fight|The inner planets unite for war.
 EOF2
 
-existing_eps=$(curl -s "$API/shows/$SHOW_ID/episodes")
+existing_eps=$(seed_api_get "$API/shows/$SHOW_ID/episodes")
 printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title description; do
   [ -z "$season" ] && continue
   if echo "$existing_eps" | jq -e --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t))|length>0' >/dev/null; then
     echo "Episode exists (S${season}): $title"
   else
     echo "Creating episode (S${season}): $title"
-    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | curl -s -X POST "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
+    jq -nc --argjson season "$season" --arg date "$air_date" --arg t "$title" --arg d "$description" '{season_number:$season, air_date:$date, title:$t, description:$d}' | seed_api_post "$API/shows/$SHOW_ID/episodes" -H 'Content-Type: application/json' -d @- >/dev/null
   fi
-  EP_ID=$(curl -s "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
+  EP_ID=$(seed_api_get "$API/shows/$SHOW_ID/episodes" | jq -r --arg t "$title" --argjson s "$season" 'map(select(.season_number==$s and .title==$t)) | (.[0].id // empty)')
   [ -z "$EP_ID" ] && { echo "Could not resolve episode id for season $season"; continue; }
 
   case "$season" in
@@ -131,7 +135,7 @@ printf '%s\n' "$EPISODES" | while IFS='|' read -r season air_date title descript
   echo "$CHARS" | tr '|' '\n' | while IFS= read -r char; do
     [ -z "$char" ] && continue
     echo "  Linking $char"
-    curl -s -X POST "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
+    seed_api_post "$API/episodes/$EP_ID/characters" -H 'Content-Type: application/json' -d "$(jq -nc --arg n "$char" '{character_name:$n}')" >/dev/null
   done
 done
 


### PR DESCRIPTION
## Summary
- add a shared seed helper that wraps curl with retry/backoff logic and reports init status consistently
- update all shell seeders to source the helper, call seed_init_database, and use the retry-aware API helpers instead of raw curl

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc8015807483219e23a478ad67ca0c