### PR TITLE
feat: reset database via api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] - 2025-09-23
+### Added
+- POST `/admin/reset-database` endpoint to drop and reinitialize the schema via the API.
+- API smoke test coverage for the admin reset workflow.
+
+### Changed
+- `reset_database.sh` now calls the admin API instead of executing SQL locally.
+- README, OpenAPI spec, Postman collection, Docker, Helm, and Kubernetes defaults bumped to 1.2.0.
+
 ## [1.1.0] - 2025-09-22
 ### Changed
 - Adopted a semantic version baseline of 1.1.0 across the package, specs, and deployment assets.

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ npm run docker:build -- --push
 ```
 By default the helper script builds an x86_64 image locally (loaded into your Docker daemon). Pass `--push` to publish the multi-architecture image set.
 
-Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.1.0`) plus a numeric suffix such as `1.1.0.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
+Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.2.0`) plus a numeric suffix such as `1.2.0.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
 
 ### Helm deployment
 Render the manifests without installing:
@@ -101,8 +101,9 @@ Seeds seasons 1–26, a subset of actors & characters, one opener episode per se
 ./reset_database.sh       # prompts before dropping data
 ./reset_database.sh --force  # skip the confirmation prompt
 ```
-Uses the same MySQL environment variables as `server.js` (`DB_HOST`, `DB_PORT`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`).
-The script drops and recreates the schema defined in `schema.sql`, so reseed scripts start from an empty database.
+Targets the running API at `$API_BASE_URL` (default `http://localhost:$PORT`) and
+invokes `POST /admin/reset-database` using the optional `$API_TOKEN` header.
+Make sure the server is running so reseed scripts start from an empty database.
 
 ---
 

--- a/charts/tvdb/Chart.yaml
+++ b/charts/tvdb/Chart.yaml
@@ -3,4 +3,4 @@ name: tvdb
 description: A Helm chart for the tvdb application.
 type: application
 version: 0.1.0
-appVersion: "1.1.0"
+appVersion: "1.2.0"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,12 +27,12 @@ services:
     ports:
       - "6888:80"
   tvdb:
-    image: ${TVDB_IMAGE:-ravelox/tvdb:1.1.0}
+    image: ${TVDB_IMAGE:-ravelox/tvdb:1.2.0}
     build:
       context: .
       args:
         NODE_VERSION: ${NODE_VERSION:-20.12.2-slim}
-        APP_VERSION: ${APP_VERSION:-1.1.0}
+        APP_VERSION: ${APP_VERSION:-1.2.0}
         BUILD_NUMBER: ${BUILD_NUMBER:-0}
     restart: always
     depends_on:

--- a/k8s/tvdb-app-deployment.yaml
+++ b/k8s/tvdb-app-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         command: ['sh', '-c', 'until nc -zv tvdb-database 3306; do echo waiting for database; sleep 2; done']
       containers:
       - name: tvdb-app
-        image: ravelox/tvdb:1.1.0
+        image: ravelox/tvdb:1.2.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [
@@ -34,6 +34,9 @@
     },
     {
       "name": "jobs"
+    },
+    {
+      "name": "admin"
     }
   ],
   "components": {
@@ -216,6 +219,19 @@
         "responses": {
           "200": {
             "description": "Initialized"
+          }
+        }
+      }
+    },
+    "/admin/reset-database": {
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "summary": "Reset database schema via API",
+        "responses": {
+          "200": {
+            "description": "Reset"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -38,6 +38,7 @@ after(() => {
 const endpoints = [
   { method: 'GET', path: '/health' },
   { method: 'POST', path: '/init' },
+  { method: 'POST', path: '/admin/reset-database' },
   { method: 'POST', path: '/actors', body: { name: 'Tester' }, expect: 201 },
   { method: 'GET', path: '/actors' },
   { method: 'GET', path: '/actors/1', expect: 404 },

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [
@@ -31,6 +31,19 @@
             "method": "POST",
             "url": "{{baseUrl}}/init",
             "description": "Initialize DB/schema"
+          }
+        }
+      ]
+    },
+    {
+      "name": "admin",
+      "item": [
+        {
+          "name": "POST /admin/reset-database",
+          "request": {
+            "method": "POST",
+            "url": "{{baseUrl}}/admin/reset-database",
+            "description": "Reset database schema via API"
           }
         }
       ]


### PR DESCRIPTION
## Summary
- add a POST /admin/reset-database endpoint that drops and reinitializes the schema before recreating the connection pool
- switch reset_database.sh to call the API endpoint and update the README plus generated docs for the new admin surface
- regenerate the Postman collection and extend the API test harness to cover the reset workflow
- bump package metadata, documentation, and deployment manifests to version 1.2.0

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc937e8fbc832192a4ccbbe0c98df2