### PR TITLE
Add standalone explorer web app with auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ The API exposes a few optional environment variables for authentication and back
 
 See `.env.example` for a compose-ready set of defaults.
 
+### TV Explorer web app
+
+The repository ships with a standalone client experience at [`/explorer`](http://localhost:3000/explorer/) that consumes the same REST API as the admin console. The page is compiled from static assets under `public/explorer` and offers:
+
+- Token-based authentication: when `API_TOKEN` is set, the app prompts for the token and stores it in the browser's `localStorage`. You can re-enter or clear the token at any time with the **Change API Token** button in the header.
+- Hierarchical navigation: pick a show, then drill into its seasons, episode lists, and per-episode details with modern cards and chips.
+- Character overviews: every show's characters (and their actors, when known) are displayed alongside the season/episode explorer.
+
+Start the server (`npm start`) and open the `/explorer` route in a browser to try it out.
+
 ### Uninstall / Cleanup
 
 When you're done experimenting you can tear everything down:

--- a/public/explorer/app.js
+++ b/public/explorer/app.js
@@ -1,0 +1,402 @@
+(() => {
+  const state = {
+    token: '',
+    shows: [],
+    seasons: [],
+    episodes: [],
+    characters: [],
+    selectedShowId: null,
+    selectedSeasonNumber: null,
+    selectedEpisodeId: null,
+  };
+
+  const elements = {
+    showSelect: document.getElementById('show-select'),
+    showTitle: document.getElementById('show-title'),
+    showMeta: document.getElementById('show-meta'),
+    showDescription: document.getElementById('show-description'),
+    seasonList: document.getElementById('season-list'),
+    episodesList: document.getElementById('episodes-list'),
+    episodeDetails: document.getElementById('episode-details'),
+    charactersGrid: document.getElementById('characters-grid'),
+    connectionStatus: document.getElementById('connection-status'),
+    toast: document.getElementById('toast'),
+    authModal: document.getElementById('auth-modal'),
+    authForm: document.getElementById('auth-form'),
+    authTokenInput: document.getElementById('auth-token'),
+    authCancel: document.getElementById('auth-cancel'),
+    changeTokenBtn: document.getElementById('change-token-btn'),
+  };
+
+  let toastTimer = null;
+  let showRequestToken = 0;
+
+  function updateConnectionStatus(status) {
+    const pill = elements.connectionStatus;
+    pill.classList.remove('status-pill--connected', 'status-pill--error', 'status-pill--disconnected');
+    switch (status) {
+      case 'connected':
+        pill.textContent = 'Connected';
+        pill.classList.add('status-pill--connected');
+        break;
+      case 'error':
+        pill.textContent = 'Error';
+        pill.classList.add('status-pill--error');
+        break;
+      default:
+        pill.textContent = 'Disconnected';
+        pill.classList.add('status-pill--disconnected');
+    }
+  }
+
+  function showToast(message) {
+    const toast = elements.toast;
+    toast.textContent = message;
+    toast.classList.add('toast--visible');
+    if (toastTimer) clearTimeout(toastTimer);
+    toastTimer = setTimeout(() => {
+      toast.classList.remove('toast--visible');
+    }, 3000);
+  }
+
+  function openAuthModal() {
+    elements.authModal.hidden = false;
+    requestAnimationFrame(() => {
+      elements.authTokenInput.focus();
+    });
+  }
+
+  function closeAuthModal() {
+    elements.authModal.hidden = true;
+    elements.authForm.reset();
+  }
+
+  function persistToken(token) {
+    state.token = token;
+    if (token) {
+      localStorage.setItem('tvdb_api_token', token);
+    } else {
+      localStorage.removeItem('tvdb_api_token');
+    }
+  }
+
+  function handleUnauthorized() {
+    persistToken('');
+    updateConnectionStatus('disconnected');
+    openAuthModal();
+    showToast('Authentication required. Enter a valid API token.');
+    throw new Error('Unauthorized');
+  }
+
+  async function apiFetch(path, options = {}) {
+    const headers = new Headers(options.headers || {});
+    if (state.token) {
+      headers.set('Authorization', `Bearer ${state.token}`);
+    }
+    const response = await fetch(path, { ...options, headers });
+    if (response.status === 401) {
+      handleUnauthorized();
+    }
+    if (!response.ok) {
+      let message = `Request failed (${response.status})`;
+      try {
+        const data = await response.json();
+        if (data && data.error) message = data.error;
+      } catch (err) {
+        // ignore JSON parse errors
+      }
+      throw new Error(message);
+    }
+    if (response.status === 204) return null;
+    return response.json();
+  }
+
+  function renderShowDetails(show) {
+    if (!show) {
+      elements.showTitle.textContent = 'Select a show to see details';
+      elements.showMeta.textContent = '';
+      elements.showDescription.textContent = '';
+      return;
+    }
+    elements.showTitle.textContent = show.title;
+    const metaParts = [];
+    if (show.year) metaParts.push(show.year);
+    if (show.created_at) {
+      const created = new Date(show.created_at);
+      if (!Number.isNaN(created.getTime())) {
+        metaParts.push(`Added ${created.toLocaleDateString()}`);
+      }
+    }
+    elements.showMeta.textContent = metaParts.join(' • ');
+    elements.showDescription.textContent = show.description || 'No description available yet for this show.';
+  }
+
+  function renderSeasons() {
+    const container = elements.seasonList;
+    container.innerHTML = '';
+    if (!state.seasons.length) {
+      container.innerHTML = '<div class="empty-state">No seasons found for this show.</div>';
+      return;
+    }
+    for (const season of state.seasons) {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'season-chip' + (season.season_number === state.selectedSeasonNumber ? ' season-chip--active' : '');
+      button.textContent = `Season ${season.season_number}`;
+      button.dataset.seasonNumber = String(season.season_number);
+      container.appendChild(button);
+    }
+  }
+
+  function renderEpisodes() {
+    const list = elements.episodesList;
+    list.innerHTML = '';
+    if (!state.selectedSeasonNumber) {
+      list.innerHTML = '<div class="empty-state">Select a season to load episodes.</div>';
+      return;
+    }
+    if (!state.episodes.length) {
+      list.innerHTML = '<div class="empty-state">No episodes found for this season.</div>';
+      return;
+    }
+    state.episodes.forEach((episode, index) => {
+      const card = document.createElement('button');
+      card.type = 'button';
+      card.className = 'episode-card' + (episode.id === state.selectedEpisodeId ? ' episode-card--active' : '');
+      card.dataset.episodeId = String(episode.id);
+      const title = document.createElement('h4');
+      title.textContent = episode.title || `Episode ${index + 1}`;
+      const info = document.createElement('p');
+      const parts = [];
+      if (episode.air_date) {
+        const airDate = new Date(episode.air_date);
+        if (!Number.isNaN(airDate.getTime())) parts.push(airDate.toLocaleDateString());
+      }
+      parts.push(`Episode ${index + 1}`);
+      info.textContent = parts.join(' • ');
+      card.appendChild(title);
+      card.appendChild(info);
+      list.appendChild(card);
+    });
+  }
+
+  function renderEpisodeDetails(episode) {
+    const panel = elements.episodeDetails;
+    panel.innerHTML = '';
+    const heading = document.createElement('h3');
+    heading.textContent = episode ? episode.title || 'Untitled episode' : 'Episode details';
+    panel.appendChild(heading);
+    if (!episode) {
+      const placeholder = document.createElement('p');
+      placeholder.className = 'muted';
+      placeholder.textContent = 'Select an episode to see its synopsis.';
+      panel.appendChild(placeholder);
+      return;
+    }
+    const meta = document.createElement('p');
+    meta.className = 'muted';
+    const bits = [];
+    if (episode.air_date) {
+      const airDate = new Date(episode.air_date);
+      if (!Number.isNaN(airDate.getTime())) bits.push(`Aired ${airDate.toLocaleDateString()}`);
+    }
+    if (state.selectedSeasonNumber != null) {
+      bits.push(`Season ${state.selectedSeasonNumber}`);
+    }
+    panel.appendChild(meta);
+    meta.textContent = bits.join(' • ');
+    const description = document.createElement('p');
+    description.textContent = episode.description || 'No description is available for this episode yet.';
+    panel.appendChild(description);
+  }
+
+  function renderCharacters() {
+    const grid = elements.charactersGrid;
+    grid.innerHTML = '';
+    if (!state.selectedShowId) {
+      grid.innerHTML = '<div class="empty-state">Select a show to view characters.</div>';
+      return;
+    }
+    if (!state.characters.length) {
+      grid.innerHTML = '<div class="empty-state">No characters available for this show.</div>';
+      return;
+    }
+    for (const character of state.characters) {
+      const card = document.createElement('article');
+      card.className = 'character-card';
+      const name = document.createElement('h4');
+      name.textContent = character.name;
+      const actor = document.createElement('span');
+      actor.textContent = character.actor_name ? `Portrayed by ${character.actor_name}` : 'No actor listed';
+      card.appendChild(name);
+      card.appendChild(actor);
+      grid.appendChild(card);
+    }
+  }
+
+  async function loadShows() {
+    try {
+      const shows = await apiFetch('/shows');
+      updateConnectionStatus('connected');
+      state.shows = Array.isArray(shows) ? shows : [];
+      if (!state.shows.length) {
+        elements.showSelect.innerHTML = '<option value="">No shows found</option>';
+        renderShowDetails(null);
+        renderSeasons();
+        renderEpisodes();
+        renderCharacters();
+        return true;
+      }
+      elements.showSelect.innerHTML = ['<option value="">Select a show...</option>']
+        .concat(state.shows.map((show) => `<option value="${show.id}">${show.title}</option>`))
+        .join('');
+      const storedShowId = state.selectedShowId || Number(elements.showSelect.value);
+      const defaultShowId = storedShowId || state.shows[0].id;
+      elements.showSelect.value = String(defaultShowId);
+      await selectShow(defaultShowId);
+      return true;
+    } catch (error) {
+      console.error(error);
+      if (error.message !== 'Unauthorized') {
+        updateConnectionStatus('error');
+        showToast(error.message);
+      }
+      return false;
+    }
+  }
+
+  async function selectShow(showId) {
+    if (!showId) {
+      state.selectedShowId = null;
+      state.seasons = [];
+      state.characters = [];
+      state.episodes = [];
+      state.selectedSeasonNumber = null;
+      state.selectedEpisodeId = null;
+      renderShowDetails(null);
+      renderSeasons();
+      renderEpisodes();
+      renderCharacters();
+      return;
+    }
+    state.selectedShowId = Number(showId);
+    const show = state.shows.find((item) => item.id === state.selectedShowId);
+    renderShowDetails(show);
+    const requestId = ++showRequestToken;
+    try {
+      const [seasons, characters] = await Promise.all([
+        apiFetch(`/shows/${state.selectedShowId}/seasons`),
+        apiFetch(`/shows/${state.selectedShowId}/characters`),
+      ]);
+      updateConnectionStatus('connected');
+      if (requestId !== showRequestToken) return;
+      state.seasons = Array.isArray(seasons) ? seasons : [];
+      state.characters = Array.isArray(characters) ? characters : [];
+      state.selectedSeasonNumber = state.seasons[0]?.season_number || null;
+      renderSeasons();
+      renderCharacters();
+      if (state.selectedSeasonNumber != null) {
+        await selectSeason(state.selectedSeasonNumber);
+      } else {
+        state.episodes = [];
+        state.selectedEpisodeId = null;
+        renderEpisodes();
+        renderEpisodeDetails(null);
+      }
+    } catch (error) {
+      console.error(error);
+      if (error.message !== 'Unauthorized') {
+        updateConnectionStatus('error');
+        showToast(error.message);
+      }
+    }
+  }
+
+  async function selectSeason(seasonNumber) {
+    if (seasonNumber == null) return;
+    state.selectedSeasonNumber = Number(seasonNumber);
+    renderSeasons();
+    try {
+      const episodes = await apiFetch(`/shows/${state.selectedShowId}/seasons/${state.selectedSeasonNumber}/episodes`);
+      updateConnectionStatus('connected');
+      state.episodes = Array.isArray(episodes) ? episodes : [];
+      state.selectedEpisodeId = state.episodes[0]?.id || null;
+      renderEpisodes();
+      const selectedEpisode = state.episodes.find((ep) => ep.id === state.selectedEpisodeId) || null;
+      renderEpisodeDetails(selectedEpisode);
+    } catch (error) {
+      console.error(error);
+      if (error.message !== 'Unauthorized') {
+        updateConnectionStatus('error');
+        showToast(error.message);
+      }
+    }
+  }
+
+  function selectEpisode(episodeId) {
+    state.selectedEpisodeId = Number(episodeId);
+    renderEpisodes();
+    const episode = state.episodes.find((ep) => ep.id === state.selectedEpisodeId) || null;
+    renderEpisodeDetails(episode);
+  }
+
+  function attachEventListeners() {
+    elements.showSelect.addEventListener('change', (event) => {
+      selectShow(Number(event.target.value));
+    });
+
+    elements.seasonList.addEventListener('click', (event) => {
+      const target = event.target;
+      if (target instanceof HTMLElement && target.dataset.seasonNumber) {
+        selectSeason(Number(target.dataset.seasonNumber));
+      }
+    });
+
+    elements.episodesList.addEventListener('click', (event) => {
+      const target = event.target instanceof HTMLElement ? event.target.closest('.episode-card') : null;
+      if (target && target.dataset.episodeId) {
+        selectEpisode(Number(target.dataset.episodeId));
+      }
+    });
+
+    elements.authForm.addEventListener('submit', async (event) => {
+      event.preventDefault();
+      const token = elements.authTokenInput.value.trim();
+      if (!token) return;
+      persistToken(token);
+      closeAuthModal();
+      const ok = await loadShows();
+      if (ok) {
+        showToast('Connected to the API.');
+      }
+    });
+
+    elements.authCancel.addEventListener('click', () => {
+      closeAuthModal();
+      if (!state.token) {
+        updateConnectionStatus('disconnected');
+      }
+    });
+
+    elements.changeTokenBtn.addEventListener('click', () => {
+      elements.authTokenInput.value = state.token;
+      openAuthModal();
+    });
+  }
+
+  async function bootstrap() {
+    attachEventListeners();
+    const storedToken = localStorage.getItem('tvdb_api_token');
+    if (storedToken) {
+      persistToken(storedToken);
+      const ok = await loadShows();
+      if (ok) {
+        return;
+      }
+    }
+    updateConnectionStatus('disconnected');
+    openAuthModal();
+  }
+
+  bootstrap();
+})();

--- a/public/explorer/index.html
+++ b/public/explorer/index.html
@@ -1,0 +1,84 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>TV Explorer</title>
+    <link rel="stylesheet" href="./styles.css" />
+    <script defer src="./app.js"></script>
+  </head>
+  <body>
+    <div class="app-shell">
+      <header class="top-bar">
+        <div class="brand">
+          <h1>TV Explorer</h1>
+          <p>Browse shows, seasons, episodes, and characters from the TV API.</p>
+        </div>
+        <div class="top-actions">
+          <span id="connection-status" class="status-pill status-pill--disconnected" role="status">Disconnected</span>
+          <button id="change-token-btn" class="ghost-button" type="button">Change API Token</button>
+        </div>
+      </header>
+
+      <main class="layout">
+        <section class="card show-card" aria-labelledby="shows-heading">
+          <header class="card-header">
+            <h2 id="shows-heading">Shows</h2>
+            <p class="card-subtitle">Choose a show to explore its world.</p>
+          </header>
+          <div class="control-group">
+            <label class="field-label" for="show-select">Available shows</label>
+            <select id="show-select" class="select-field">
+              <option value="">Loading shows...</option>
+            </select>
+          </div>
+          <div id="show-details" class="card-body">
+            <h3 id="show-title" class="show-title">Select a show to see details</h3>
+            <p id="show-meta" class="show-meta"></p>
+            <p id="show-description" class="show-description"></p>
+          </div>
+        </section>
+
+        <section class="card episodes-card" aria-labelledby="episodes-heading">
+          <header class="card-header">
+            <h2 id="episodes-heading">Seasons &amp; Episodes</h2>
+            <p class="card-subtitle">Pick a season to reveal its episodes.</p>
+          </header>
+          <div id="season-list" class="season-list" role="list" aria-live="polite"></div>
+          <div id="episodes-container" class="episodes-container">
+            <div id="episodes-list" class="episodes-list" aria-live="polite"></div>
+            <aside id="episode-details" class="episode-details" aria-live="polite">
+              <h3>Episode details</h3>
+              <p class="muted">Select an episode to see its synopsis.</p>
+            </aside>
+          </div>
+        </section>
+
+        <section class="card characters-card" aria-labelledby="characters-heading">
+          <header class="card-header">
+            <h2 id="characters-heading">Characters</h2>
+            <p class="card-subtitle">Meet the people that bring the story to life.</p>
+          </header>
+          <div id="characters-grid" class="characters-grid" aria-live="polite"></div>
+        </section>
+      </main>
+    </div>
+
+    <div id="toast" class="toast" role="status" aria-live="polite"></div>
+
+    <div id="auth-modal" class="auth-modal" role="dialog" aria-modal="true" aria-labelledby="auth-title" hidden>
+      <div class="auth-card">
+        <h2 id="auth-title">Connect to the API</h2>
+        <p class="muted">Enter the API token configured on the server to continue.</p>
+        <form id="auth-form" class="auth-form">
+          <label class="field-label" for="auth-token">API token</label>
+          <input id="auth-token" name="token" type="password" class="text-field" autocomplete="off" required />
+          <div class="auth-actions">
+            <button type="submit" class="primary-button">Connect</button>
+            <button type="button" id="auth-cancel" class="ghost-button">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/public/explorer/styles.css
+++ b/public/explorer/styles.css
@@ -1,0 +1,433 @@
+:root {
+  color-scheme: dark;
+  --bg-gradient: radial-gradient(circle at top left, #1f2937, #0f172a 55%, #020617 100%);
+  --card-bg: rgba(15, 23, 42, 0.85);
+  --card-border: rgba(148, 163, 184, 0.18);
+  --muted: #94a3b8;
+  --accent: #38bdf8;
+  --accent-muted: rgba(56, 189, 248, 0.14);
+  --accent-strong: #0ea5e9;
+  --text-primary: #f8fafc;
+  --text-secondary: #cbd5f5;
+  --danger: #f87171;
+  --radius: 16px;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  font-family: inherit;
+  line-height: 1.5;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  backdrop-filter: blur(40px);
+  background-color: rgba(15, 23, 42, 0.32);
+}
+
+.top-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 32px clamp(24px, 5vw, 64px) 16px;
+}
+
+.brand h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 2.5vw, 2.75rem);
+  letter-spacing: -0.03em;
+}
+
+.brand p {
+  margin: 8px 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.top-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: var(--muted);
+  transition: background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.status-pill::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.status-pill--connected {
+  background: var(--accent-muted);
+  border-color: rgba(56, 189, 248, 0.35);
+  color: var(--accent);
+}
+
+.status-pill--error {
+  background: rgba(248, 113, 113, 0.12);
+  border-color: rgba(248, 113, 113, 0.24);
+  color: var(--danger);
+}
+
+.layout {
+  display: grid;
+  gap: 32px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  padding: 0 clamp(24px, 5vw, 64px) 48px;
+}
+
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: var(--radius);
+  box-shadow: 0 24px 50px rgba(2, 6, 23, 0.6);
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  position: relative;
+  overflow: hidden;
+}
+
+.card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.14), rgba(56, 189, 248, 0));
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+.card:hover::after {
+  opacity: 1;
+}
+
+.card-header h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.card-subtitle {
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.field-label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.select-field,
+.text-field {
+  border-radius: 12px;
+  padding: 12px 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-primary);
+  font-size: 1rem;
+  transition: border 0.2s ease, box-shadow 0.2s ease;
+}
+
+.select-field:focus,
+.text-field:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.7);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.show-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.show-meta {
+  margin: 6px 0 0;
+  color: var(--muted);
+}
+
+.show-description {
+  margin: 12px 0 0;
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.season-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  min-height: 42px;
+}
+
+.season-chip {
+  border-radius: 999px;
+  padding: 8px 16px;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+  font-weight: 600;
+  font-size: 0.9rem;
+  border: 1px solid transparent;
+  cursor: pointer;
+  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.season-chip:hover {
+  transform: translateY(-1px);
+}
+
+.season-chip--active {
+  background: var(--accent-muted);
+  color: var(--accent);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.episodes-container {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(240px, 280px);
+  gap: 20px;
+}
+
+.episodes-list {
+  display: grid;
+  gap: 12px;
+}
+
+.episode-card {
+  padding: 16px;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  background: rgba(15, 23, 42, 0.7);
+  cursor: pointer;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+}
+
+.episode-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.45);
+}
+
+.episode-card--active {
+  border-color: rgba(56, 189, 248, 0.8);
+  background: rgba(14, 165, 233, 0.12);
+}
+
+.episode-card h4 {
+  margin: 0 0 6px;
+  font-size: 1rem;
+}
+
+.episode-card p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.episode-details {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(14, 23, 42, 0.55);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.episode-details h3 {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.episode-details .muted,
+.muted {
+  color: var(--muted);
+}
+
+.characters-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 16px;
+  min-height: 120px;
+}
+
+.character-card {
+  padding: 16px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
+}
+
+.character-card:hover {
+  transform: translateY(-2px);
+  border-color: rgba(56, 189, 248, 0.4);
+}
+
+.character-card h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.character-card span {
+  color: var(--muted);
+  font-size: 0.85rem;
+}
+
+.primary-button,
+.ghost-button {
+  border-radius: 12px;
+  padding: 10px 18px;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease, border 0.2s ease;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, var(--accent-strong), #38bdf8);
+  border: 1px solid transparent;
+  color: #0f172a;
+  box-shadow: 0 14px 30px rgba(14, 165, 233, 0.25);
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 38px rgba(14, 165, 233, 0.35);
+}
+
+.ghost-button {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.32);
+  color: var(--text-primary);
+}
+
+.ghost-button:hover {
+  border-color: rgba(148, 163, 184, 0.6);
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.toast {
+  position: fixed;
+  bottom: 28px;
+  left: 50%;
+  transform: translateX(-50%) translateY(120%);
+  padding: 14px 20px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.9);
+  border: 1px solid rgba(56, 189, 248, 0.32);
+  color: var(--text-primary);
+  min-width: 240px;
+  text-align: center;
+  opacity: 0;
+  transition: transform 0.3s ease, opacity 0.3s ease;
+  pointer-events: none;
+  z-index: 20;
+}
+
+.toast--visible {
+  transform: translateX(-50%) translateY(0);
+  opacity: 1;
+}
+
+.auth-modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(2, 6, 23, 0.8);
+  backdrop-filter: blur(12px);
+  z-index: 30;
+}
+
+.auth-card {
+  width: min(420px, 90vw);
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 20px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 32px;
+  box-shadow: 0 30px 60px rgba(2, 6, 23, 0.5);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.auth-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.auth-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 960px) {
+  .episodes-container {
+    grid-template-columns: 1fr;
+  }
+
+  .episode-details {
+    order: -1;
+  }
+}
+
+@media (max-width: 720px) {
+  .top-bar {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .layout {
+    padding-bottom: 80px;
+  }
+}
+
+.empty-state {
+  border: 1px dashed rgba(148, 163, 184, 0.3);
+  border-radius: 12px;
+  padding: 18px;
+  text-align: center;
+  color: var(--muted);
+  font-size: 0.95rem;
+}

--- a/server.js
+++ b/server.js
@@ -136,6 +136,8 @@ if (ENABLE_ADMIN_UI) {
   console.log('[admin] Admin UI disabled (set ENABLE_ADMIN_UI=true to enable)');
 }
 
+app.use('/explorer', express.static(path.join(__dirname, 'public', 'explorer')));
+
 const PUBLIC_AUTH_PATHS = [
   /^\/docs(?:\/|$)/,
   /^\/openapi\.json$/,


### PR DESCRIPTION
## Summary
- add a static Explorer client at /explorer that lets users browse shows, seasons, episodes, and characters with a modern layout
- handle API token authentication in the client and document the new experience in the README
- expose the explorer assets from the Express server alongside the existing admin UI

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cde167a7dc8321948d6ed5d564dbc0