### PR TITLE
Handle localStorage errors in API token modal

### DIFF
--- a/public/explorer/app.js
+++ b/public/explorer/app.js
@@ -73,10 +73,17 @@
 
   function persistToken(token) {
     state.token = token;
-    if (token) {
-      localStorage.setItem('tvdb_api_token', token);
-    } else {
-      localStorage.removeItem('tvdb_api_token');
+    try {
+      if (token) {
+        localStorage.setItem('tvdb_api_token', token);
+      } else {
+        localStorage.removeItem('tvdb_api_token');
+      }
+    } catch (error) {
+      console.warn('Failed to persist API token to localStorage', error);
+      if (token) {
+        showToast('Connected, but unable to remember the API token in this browser.');
+      }
     }
   }
 
@@ -386,7 +393,12 @@
 
   async function bootstrap() {
     attachEventListeners();
-    const storedToken = localStorage.getItem('tvdb_api_token');
+    let storedToken = null;
+    try {
+      storedToken = localStorage.getItem('tvdb_api_token');
+    } catch (error) {
+      console.warn('Failed to read API token from localStorage', error);
+    }
     if (storedToken) {
       persistToken(storedToken);
       const ok = await loadShows();


### PR DESCRIPTION
## Summary
- guard API token persistence against localStorage failures so the modal always closes
- surface a toast warning when the token cannot be saved and log read/write errors
- avoid crashing bootstrap when browsers block access to localStorage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdeaf9a6608321a6b6710c8c2a5917