### PR TITLE
Prune Docker Hub tags to keep latest builds

### DIFF
--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -7,6 +7,103 @@ node_version="20.12.2-slim"
 push_image=false
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_dir="$(cd "${script_dir}/.." && pwd)"
+repository="${DOCKERHUB_REPOSITORY:-ravelox/tvdb}"
+keep_build_tag_count="${DOCKERHUB_KEEP_BUILDS:-2}"
+
+prune_old_build_tags() {
+  local repository="$1"
+  local app_version="$2"
+  local keep_count="${3:-2}"
+
+  if [[ ! "$keep_count" =~ ^[0-9]+$ ]]; then
+    echo "Invalid keep count '${keep_count}'; defaulting to 2." >&2
+    keep_count=2
+  fi
+
+  if (( keep_count < 1 )); then
+    keep_count=1
+  fi
+
+  local username="${DOCKERHUB_USERNAME:-}"
+  local password="${DOCKERHUB_PASSWORD:-${DOCKERHUB_TOKEN:-}}"
+
+  if [[ -z "$username" || -z "$password" ]]; then
+    echo "Skipping Docker Hub tag pruning; DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD (or DOCKERHUB_TOKEN) must be set." >&2
+    return
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "Skipping Docker Hub tag pruning; jq is required." >&2
+    return
+  fi
+
+  local login_payload
+  login_payload=$(jq -n --arg username "$username" --arg password "$password" '{username:$username, password:$password}')
+
+  local token_response
+  if ! token_response=$(curl -fsSL -H "Content-Type: application/json" -d "$login_payload" "https://hub.docker.com/v2/users/login/"); then
+    echo "Failed to authenticate with Docker Hub; skipping tag pruning." >&2
+    return
+  fi
+
+  local token
+  token=$(jq -r '.token // empty' <<<"$token_response")
+
+  if [[ -z "$token" ]]; then
+    echo "Docker Hub authentication response did not include a token; skipping tag pruning." >&2
+    return
+  fi
+
+  local api_url="https://hub.docker.com/v2/repositories/${repository}/tags/?page_size=100"
+  local tags=()
+  local escaped_app_version="${app_version//./\\.}"
+
+  while [[ -n "$api_url" ]]; do
+    local page
+    if ! page=$(curl -fsSL -H "Authorization: JWT $token" "$api_url"); then
+      echo "Failed to fetch Docker Hub tags; skipping tag pruning." >&2
+      return
+    fi
+
+    while IFS= read -r tag_name; do
+      if [[ "$tag_name" =~ ^${escaped_app_version}\.([0-9]+)$ ]]; then
+        tags+=("$tag_name:${BASH_REMATCH[1]}")
+      fi
+    done < <(jq -r '.results[].name' <<<"$page")
+
+    api_url=$(jq -r '.next // empty' <<<"$page")
+  done
+
+  if (( ${#tags[@]} <= keep_count )); then
+    echo "Docker Hub currently has ${#tags[@]} build tag(s) for ${app_version}; nothing to prune."
+    return
+  fi
+
+  mapfile -t sorted_tags < <(printf '%s\n' "${tags[@]}" | sort -t: -k2,2nr)
+
+  local keep_tags=()
+  for entry in "${sorted_tags[@]:0:keep_count}"; do
+    keep_tags+=("${entry%%:*}")
+  done
+
+  local deleted=0
+  for entry in "${sorted_tags[@]:keep_count}"; do
+    local tag="${entry%%:*}"
+    local delete_url="https://hub.docker.com/v2/repositories/${repository}/tags/${tag}/"
+    if curl -fsSL -X DELETE -H "Authorization: JWT $token" "$delete_url" >/dev/null 2>&1; then
+      echo "Deleted old Docker Hub tag ${tag}"
+      ((deleted++))
+    else
+      echo "Failed to delete Docker Hub tag ${tag}" >&2
+    fi
+  done
+
+  if (( deleted > 0 )); then
+    echo "Pruned ${deleted} old Docker Hub build tag(s); kept: ${keep_tags[*]}"
+  else
+    echo "No Docker Hub tags were pruned."
+  fi
+}
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -75,7 +172,7 @@ printf '%s\n' "$next_build_number" >"$build_number_file"
 
 full_version="${app_version}.${next_build_number}"
 
-echo "Building ravelox/tvdb:${full_version} (base ${app_version}, build #${next_build_number})"
+echo "Building ${repository}:${full_version} (base ${app_version}, build #${next_build_number})"
 
 build_args=(
   docker buildx build
@@ -83,9 +180,9 @@ build_args=(
   --build-arg NODE_VERSION="$node_version"
   --build-arg APP_VERSION="$app_version"
   --build-arg BUILD_NUMBER="$next_build_number"
-  -t ravelox/tvdb:latest
-  -t ravelox/tvdb:"$app_version"
-  -t ravelox/tvdb:"$full_version"
+  -t "${repository}:latest"
+  -t "${repository}:${app_version}"
+  -t "${repository}:${full_version}"
 )
 
 if $push_image; then
@@ -95,3 +192,8 @@ else
 fi
 
 "${build_args[@]}" .
+
+if $push_image; then
+  prune_old_build_tags "$repository" "$app_version" "$keep_build_tag_count"
+fi
+


### PR DESCRIPTION
## Summary
- add Docker Hub pruning helper to the docker build script so only the latest two build-number tags remain on Docker Hub
- reuse the configured repository name for tagging and allow overriding the retained build count via environment variables

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce1fc1ce608321a79f9a3a703acc8f