### PR TITLE
Fix auth modal dismissal on successful connect

### DIFF
--- a/public/explorer/app.js
+++ b/public/explorer/app.js
@@ -371,9 +371,9 @@
       const token = elements.authTokenInput.value.trim();
       if (!token) return;
       persistToken(token);
-      closeAuthModal();
       const ok = await loadShows();
       if (ok) {
+        closeAuthModal();
         showToast('Connected to the API.');
       }
     });


### PR DESCRIPTION
## Summary
- keep the API token dialog open until the token has been validated
- close the modal and show a success toast only after the connection succeeds

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce20b77d2c8321b6aff231b7605f87