### PR TITLE
Fix auth modal dismissal after successful token entry

### DIFF
--- a/public/explorer/styles.css
+++ b/public/explorer/styles.css
@@ -377,6 +377,10 @@ body {
   z-index: 30;
 }
 
+.auth-modal[hidden] {
+  display: none;
+}
+
 .auth-card {
   width: min(420px, 90vw);
   background: rgba(15, 23, 42, 0.9);


### PR DESCRIPTION
## Summary
- ensure the explorer auth modal honors the `hidden` attribute by adding a scoped CSS rule
- allow the API token dialog to hide correctly after a successful connection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ced8ade74c8321b58025c668b22add