### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.3.0] - 2025-09-30
+### Added
+- Standalone TV Explorer web app served at `/explorer`, featuring API token authentication, cascading show/season/episode navigation, and per-episode character displays.
+- `seed_sapphire_and_steel.sh` seeding script to populate the Sapphire & Steel catalog through the public API helpers.
+
+### Changed
+- Hardened database calls by retrying fatal connection errors, refreshing the MySQL pool on demand, and exposing the explorer bundle from the main Express app.
+- Helm deployment now annotates pods with checksums of the app and storage secrets so upgrades roll when credentials change.
+- Docker build helper accepts repository overrides and prunes older build tags after a successful push to keep registries tidy.
+
+### Fixed
+- Explorer authentication modal surfaces validation feedback, persists tokens defensively, and reliably closes after a successful connection.
+
 ## [1.2.0] - 2025-09-23
 ### Added
 - POST `/admin/reset-database` endpoint to drop and reinitialize the schema via the API.

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ npm run docker:build -- --push
 ```
 By default the helper script builds an x86_64 image locally (loaded into your Docker daemon). Pass `--push` to publish the multi-architecture image set.
 
-Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.2.0`) plus a numeric suffix such as `1.2.0.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
+Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.3.0`) plus a numeric suffix such as `1.3.0.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
 
 ### Helm deployment
 Render the manifests without installing:

--- a/charts/tvdb/Chart.yaml
+++ b/charts/tvdb/Chart.yaml
@@ -3,4 +3,4 @@ name: tvdb
 description: A Helm chart for the tvdb application.
 type: application
 version: 0.1.0
-appVersion: "1.2.0"
+appVersion: "1.3.0"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,12 +27,12 @@ services:
     ports:
       - "6888:80"
   tvdb:
-    image: ${TVDB_IMAGE:-ravelox/tvdb:1.2.0}
+    image: ${TVDB_IMAGE:-ravelox/tvdb:1.3.0}
     build:
       context: .
       args:
         NODE_VERSION: ${NODE_VERSION:-20.12.2-slim}
-        APP_VERSION: ${APP_VERSION:-1.2.0}
+        APP_VERSION: ${APP_VERSION:-1.3.0}
         BUILD_NUMBER: ${BUILD_NUMBER:-0}
     restart: always
     depends_on:

--- a/k8s/tvdb-app-deployment.yaml
+++ b/k8s/tvdb-app-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         command: ['sh', '-c', 'until nc -zv tvdb-database 3306; do echo waiting for database; sleep 2; done']
       containers:
       - name: tvdb-app
-        image: ravelox/tvdb:1.2.0
+        image: ravelox/tvdb:1.3.0
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [


### PR DESCRIPTION
## Summary
- bump the project version to 1.3.0 across package metadata, deployment manifests, and client tooling
- document the 1.3.0 release in the changelog covering the new explorer app, seeding script, and supporting infrastructure updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cede65edf4832184749d60aeeeb75c