### PR TITLE
Fix episode character linking to preserve actor associations

### DIFF
--- a/lib/characterUpsert.js
+++ b/lib/characterUpsert.js
@@ -1,0 +1,16 @@
+function buildCharacterUpsert({ showId, name, actorId, shouldUpdateActor }) {
+  if (!showId) throw new Error('showId is required');
+  if (!name) throw new Error('name is required');
+
+  const params = [showId, name, shouldUpdateActor ? (actorId ?? null) : null];
+  const sqlBase =
+    'INSERT INTO characters (show_id, name, actor_id) VALUES (?, ?, ?) ON DUPLICATE KEY UPDATE ';
+
+  const sql = shouldUpdateActor
+    ? `${sqlBase}actor_id=VALUES(actor_id), id=LAST_INSERT_ID(id)`
+    : `${sqlBase}id=LAST_INSERT_ID(id)`;
+
+  return { sql, params };
+}
+
+module.exports = { buildCharacterUpsert };

--- a/test/characterUpsert.test.js
+++ b/test/characterUpsert.test.js
@@ -1,0 +1,41 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+
+const { buildCharacterUpsert } = require('../lib/characterUpsert');
+
+test('buildCharacterUpsert preserves actor when not updating', () => {
+  const { sql, params } = buildCharacterUpsert({
+    showId: 1,
+    name: 'James Holden',
+    actorId: undefined,
+    shouldUpdateActor: false,
+  });
+
+  assert.ok(sql.includes('ON DUPLICATE KEY UPDATE'));
+  assert.ok(!sql.includes('actor_id=VALUES(actor_id)'), 'should not update actor_id');
+  assert.deepStrictEqual(params, [1, 'James Holden', null]);
+});
+
+test('buildCharacterUpsert updates actor when requested', () => {
+  const { sql, params } = buildCharacterUpsert({
+    showId: 2,
+    name: 'Naomi Nagata',
+    actorId: 7,
+    shouldUpdateActor: true,
+  });
+
+  assert.ok(sql.includes('actor_id=VALUES(actor_id)'));
+  assert.deepStrictEqual(params, [2, 'Naomi Nagata', 7]);
+});
+
+test('buildCharacterUpsert clears actor when requested', () => {
+  const { sql, params } = buildCharacterUpsert({
+    showId: 3,
+    name: 'Alex Kamal',
+    actorId: null,
+    shouldUpdateActor: true,
+  });
+
+  assert.ok(sql.includes('actor_id=VALUES(actor_id)'));
+  assert.deepStrictEqual(params, [3, 'Alex Kamal', null]);
+});


### PR DESCRIPTION
## Summary
- prevent episode character linking from clearing an existing actor when no new actor data is supplied
- extract reusable helper for character upsert queries and cover it with unit tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2b3f351608321a1ba3d44a1f8f007