### PR TITLE
Convert explorer navigation to dropdowns

### DIFF
--- a/public/explorer/index.html
+++ b/public/explorer/index.html
@@ -45,9 +45,21 @@
             <h2 id="episodes-heading">Seasons &amp; Episodes</h2>
             <p class="card-subtitle">Pick a season to reveal its episodes.</p>
           </header>
-          <div id="season-list" class="season-list" role="list" aria-live="polite"></div>
+          <div class="control-group">
+            <label class="field-label" for="season-select">Season</label>
+            <select id="season-select" class="select-field" disabled>
+              <option value="">Select a show to load seasons</option>
+            </select>
+          </div>
           <div id="episodes-container" class="episodes-container">
-            <div id="episodes-list" class="episodes-list" aria-live="polite"></div>
+            <div class="episode-selection">
+              <div class="control-group">
+                <label class="field-label" for="episode-select">Episode</label>
+                <select id="episode-select" class="select-field" disabled>
+                  <option value="">Select a season to load episodes</option>
+                </select>
+              </div>
+            </div>
             <aside id="episode-details" class="episode-details" aria-live="polite">
               <h3>Episode details</h3>
               <p class="muted">Select an episode to see its synopsis.</p>
@@ -60,7 +72,16 @@
             <h2 id="characters-heading">Characters</h2>
             <p class="card-subtitle">Meet the people that bring the story to life.</p>
           </header>
-          <div id="characters-grid" class="characters-grid" aria-live="polite"></div>
+          <div class="control-group">
+            <label class="field-label" for="character-select">Characters in this episode</label>
+            <select id="character-select" class="select-field" disabled>
+              <option value="">Select an episode to view characters</option>
+            </select>
+          </div>
+          <div id="character-details" class="character-details" aria-live="polite">
+            <h3>Character details</h3>
+            <p class="muted">Select an episode to view characters.</p>
+          </div>
         </section>
       </main>
     </div>

--- a/public/explorer/styles.css
+++ b/public/explorer/styles.css
@@ -170,6 +170,7 @@ body {
   color: var(--text-primary);
   font-size: 1rem;
   transition: border 0.2s ease, box-shadow 0.2s ease;
+  width: 100%;
 }
 
 .select-field:focus,
@@ -189,80 +190,24 @@ body {
   color: var(--muted);
 }
 
+
 .show-description {
   margin: 12px 0 0;
   color: var(--text-secondary);
   font-size: 0.95rem;
 }
 
-.season-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  min-height: 42px;
-}
-
-.season-chip {
-  border-radius: 999px;
-  padding: 8px 16px;
-  background: rgba(148, 163, 184, 0.12);
-  color: var(--muted);
-  font-weight: 600;
-  font-size: 0.9rem;
-  border: 1px solid transparent;
-  cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease, border-color 0.2s ease;
-}
-
-.season-chip:hover {
-  transform: translateY(-1px);
-}
-
-.season-chip--active {
-  background: var(--accent-muted);
-  color: var(--accent);
-  border-color: rgba(56, 189, 248, 0.45);
-}
-
 .episodes-container {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(240px, 280px);
   gap: 20px;
+  align-items: start;
 }
 
-.episodes-list {
-  display: grid;
-  gap: 12px;
-}
-
-.episode-card {
-  padding: 16px;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  background: rgba(15, 23, 42, 0.7);
-  cursor: pointer;
-  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
-}
-
-.episode-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(56, 189, 248, 0.45);
-}
-
-.episode-card--active {
-  border-color: rgba(56, 189, 248, 0.8);
-  background: rgba(14, 165, 233, 0.12);
-}
-
-.episode-card h4 {
-  margin: 0 0 6px;
-  font-size: 1rem;
-}
-
-.episode-card p {
-  margin: 0;
-  color: var(--muted);
-  font-size: 0.9rem;
+.episode-selection {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .episode-details {
@@ -290,37 +235,20 @@ body {
   font-size: 0.85rem;
 }
 
-.characters-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 16px;
+.character-details {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(14, 23, 42, 0.55);
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
   min-height: 120px;
 }
 
-.character-card {
-  padding: 16px;
-  border-radius: 14px;
-  background: rgba(15, 23, 42, 0.7);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  transition: transform 0.2s ease, border 0.2s ease, background 0.2s ease;
-}
-
-.character-card:hover {
-  transform: translateY(-2px);
-  border-color: rgba(56, 189, 248, 0.4);
-}
-
-.character-card h4 {
+.character-details h3 {
   margin: 0;
-  font-size: 1rem;
-}
-
-.character-card span {
-  color: var(--muted);
-  font-size: 0.85rem;
+  font-size: 1.05rem;
 }
 
 .primary-button,


### PR DESCRIPTION
## Summary
- replace season, episode, and character pickers in the explorer with dropdown inputs and detail panels
- update explorer client logic to manage the new selections and character details state
- restyle the explorer layout to match the dropdown-based navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2df34c4188321abfde16e53fddd9a