### PR TITLE
chore: release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.4.1] - 2025-10-14
+### Changed
+- Explorer UI now uses cascading dropdowns for shows, seasons, episodes, and characters, providing clearer navigation and better keyboard accessibility.
+- Refined explorer layout and styling so the selected show, episode, and character details stay focused while navigation happens in the dropdowns.
+
 ## [1.4.0] - 2025-10-07
 ### Added
 - Explorer UI surfaces the running deployment version/build from `/deployment-version` so testers can confirm what they're using.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ See `.env.example` for a compose-ready set of defaults—the seed scripts automa
 The repository ships with a standalone client experience at [`/explorer`](http://localhost:3000/explorer/) that consumes the same REST API as the admin console. The page is compiled from static assets under `public/explorer` and offers:
 
 - Token-based authentication: when `API_TOKEN` is set, the app prompts for the token and stores it in the browser's `localStorage`. You can re-enter or clear the token at any time with the **Change API Token** button in the header.
-- Hierarchical navigation: pick a show, then drill into its seasons, episode lists, and per-episode details with modern cards and chips.
+- Cascading dropdown navigation: pick a show, then drill into its seasons, episodes, and characters with keyboard-friendly select menus and focused detail panes.
 - Character overviews: every show's characters (and their actors, when known) are displayed alongside the season/episode explorer.
 - Deployment awareness: the header surfaces the running application version/build using the `/deployment-version` endpoint so you can verify what you're testing.
 
@@ -81,7 +81,7 @@ npm run docker:build -- --push
 ```
 By default the helper script builds an x86_64 image locally (loaded into your Docker daemon). Pass `--push` to publish the multi-architecture image set.
 
-Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.4.0`) plus a numeric suffix such as `1.4.0.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
+Each run increments a local `.docker-build-number` counter and tags the image with the semantic package version (for example `1.4.1`) plus a numeric suffix such as `1.4.1.7`. Set the optional `APP_VERSION`/`BUILD_NUMBER` build arguments (or the matching environment variables consumed by `docker-compose.yaml`) if you need to override either value manually.
 
 ### Release automation
 

--- a/charts/tvdb/Chart.yaml
+++ b/charts/tvdb/Chart.yaml
@@ -3,4 +3,4 @@ name: tvdb
 description: A Helm chart for the tvdb application.
 type: application
 version: 0.1.0
-appVersion: "1.4.0"
+appVersion: "1.4.1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,12 +27,12 @@ services:
     ports:
       - "6888:80"
   tvdb:
-    image: ${TVDB_IMAGE:-ravelox/tvdb:1.4.0}
+    image: ${TVDB_IMAGE:-ravelox/tvdb:1.4.1}
     build:
       context: .
       args:
         NODE_VERSION: ${NODE_VERSION:-20.12.2-slim}
-        APP_VERSION: ${APP_VERSION:-1.4.0}
+        APP_VERSION: ${APP_VERSION:-1.4.1}
         BUILD_NUMBER: ${BUILD_NUMBER:-0}
     restart: always
     depends_on:

--- a/k8s/tvdb-app-deployment.yaml
+++ b/k8s/tvdb-app-deployment.yaml
@@ -21,7 +21,7 @@ spec:
         command: ['sh', '-c', 'until nc -zv tvdb-database 3306; do echo waiting for database; sleep 2; done']
       containers:
       - name: tvdb-app
-        image: ravelox/tvdb:1.4.0
+        image: ravelox/tvdb:1.4.1
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "TV Shows API",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs."
   },
   "servers": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tvshows-api",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "type": "commonjs",
   "scripts": {

--- a/tvdb.postman_collection.json
+++ b/tvdb.postman_collection.json
@@ -2,7 +2,7 @@
   "info": {
     "name": "TV Shows API",
     "description": "CRUD for shows/seasons/episodes/characters/actors, episode↔character links, and query jobs.",
-    "version": "1.4.0",
+    "version": "1.4.1",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
   },
   "item": [


### PR DESCRIPTION
## Summary
- bump release metadata to 1.4.1 across the package, API spec, and deployment defaults
- refresh the explorer documentation to call out the new dropdown navigation
- capture the explorer navigation redesign in the changelog

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d30559681883218abd9d12dd88f12a